### PR TITLE
ovn-northd-ddlog: Fix unixctl server creation.

### DIFF
--- a/northd/ovn-northd-ddlog.c
+++ b/northd/ovn-northd-ddlog.c
@@ -1177,7 +1177,14 @@ main(int argc, char *argv[])
 
     daemonize_start(false);
 
-    retval = unixctl_server_create(unixctl_path, &unixctl);
+    if (!unixctl_path) {
+        char *abs_unixctl_path = get_abs_unix_ctl_path();
+        retval = unixctl_server_create(abs_unixctl_path, &unixctl);
+        free(abs_unixctl_path);
+    } else {
+        retval = unixctl_server_create(unixctl_path, &unixctl);
+    }
+
     if (retval) {
         exit(EXIT_FAILURE);
     }


### PR DESCRIPTION
Signed-off-by: Dumitru Ceara <dceara@redhat.com>