### PR TITLE
northd/automake.mk: Extract deps from .la files for cargo.

### DIFF
--- a/northd/automake.mk
+++ b/northd/automake.mk
@@ -109,8 +109,10 @@ northd/ovn_northd_ddlog/target/release/libovn_northd_ddlog.a: \
 	lib/libovn.la            \
 	$(OVS_LIBDIR)/libopenvswitch.la
 	$(AM_V_GEN)ddlog -i $< -L @DDLOG_LIB@
+	$(eval LIBOPENVSWITCH_DEPS=$(shell sh -c "grep -oP \"dependency_libs=\'\K[^\']*\" lib/libovn.la"))
+	$(eval LIBOVN_DEPS=$(shell sh -c "grep -oP \"dependency_libs=\'\K[^\']*\" $(OVS_LIBDIR)/libopenvswitch.la"))
 	$(AM_V_at)cd northd/ovn_northd_ddlog && \
-		RUSTFLAGS="-L ../../lib/.libs -L $(OVS_LIBDIR)/.libs -lssl -lcrypto \
+		RUSTFLAGS="-L ../../lib/.libs -L $(OVS_LIBDIR)/.libs $(LIBOPENVSWITCH_DEPS) $(LIBOVN_DEPS) \
 		-Awarnings $(DDLOG_EXTRA_RUSTFLAGS)" cargo build --release \
 		$(DDLOG_NORTHD_LIB_ONLY)
 


### PR DESCRIPTION
ovn-northd-ddlog depends on `libopenvswitch.a` and `libovn.a`.
Therefore, when we compile a standalone executable (enabled by the
`--enable-ddlog-northd-cli` switch to `configure`), it must be linked
against these libraries *and* their dependencies.  The latter is tricky,
since `cargo` (the Rust build system) does not understand libtool files,
so we don't have an easy way to pull in dependencies automatically.
Until now, we dealt with this by manually listing dependencies in the
`cargo` command line.  This no longer works as OVS now has at least one
configurable dependency, the `libunwind.a` library, that is enabled by
the OVS configuration script.  This results is link errors with the latest
version of OVS.

The only solution I could come up with is to extract dependencies from
`libopenvswitch.a` and `libovn.a` using `grep` and pass them to cargo.