### PR TITLE
Fix links to ovs-advanced tutorial

### DIFF
--- a/Documentation/tutorials/ovn-sandbox.rst
+++ b/Documentation/tutorials/ovn-sandbox.rst
@@ -62,7 +62,7 @@ Using GDB
 ---------
 
 GDB support is not required to go through the tutorial. See the "Using GDB"
-section of ovs-advanced in Open vSwitch documentation for more info.
+section of `ovs-advanced`_ in Open vSwitch documentation for more info.
 Additional flags exist for launching the debugger for the OVN programs::
 
     --gdb-ovn-northd
@@ -173,3 +173,5 @@ man page for more detail.
 .. _ovn-nbctl(8): http://openvswitch.org/support/dist-docs/ovn-nbctl.8.html
 .. _ovn-sbctl(8): http://openvswitch.org/support/dist-docs/ovn-sbctl.8.html
 .. _ovn-trace(8): http://openvswitch.org/support/dist-docs/ovn-trace.8.html
+.. _ovs-advanced: https://github.com/openvswitch/ovs/blob/master/Documentation/tutorials/ovs-advanced.rst
+

--- a/README.rst
+++ b/README.rst
@@ -62,7 +62,9 @@ installation guides <Documentation/intro/install/index.rst>`__
 For answers to common questions, refer to the `FAQ <Documentation/faq>`__.
 
 To learn about some advanced features of the Open vSwitch software switch, read
-the `tutorial <Documentation/tutorials/ovs-advanced.rst>`__.
+the tutorial_.
+
+.. _tutorial: https://github.com/openvswitch/ovs/blob/master/Documentation/tutorials/ovs-advanced.rst
 
 Each OVN program is accompanied by a manpage.  Many of the manpages are customized
 to your configuration as part of the build process, so we recommend building OVN


### PR DESCRIPTION
This fixes the broken link in the README to the ovs-advanced tutorial.
This also adds a hyperlink to Documentation/tutorials/ovn-sandbox.rst
where the tutorial is referenced.

Closes #7