### PR TITLE
Fix small wording error in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,11 +12,10 @@ OVN (Open Virtual Network) is a series of daemons that translates virtual
 network configuration into OpenFlow, and installs them into Open vSwitch.
 It is licensed under the open source Apache 2 license.
 
-OVN is provides a higher-layer abstraction then Open vSwitch, working with
-logical routers and logical switches, rather than flows. OVN is intended to be
-used by cloud management software (CMS). For details about the architecture of
-OVN, see the ovn-architecture manpage. Some high-level features offered by OVN
-include
+OVN provides a higher-layer abstraction then Open vSwitch, working with logical
+routers and logical switches, rather than flows. OVN is intended to be used by
+cloud management software (CMS). For details about the architecture of OVN, see
+the ovn-architecture manpage. Some high-level features offered by OVN include:
 
 * Distributed virtual routers
 * Distributed logical switches


### PR DESCRIPTION
Fixes a small wording error in README.rst, and reformats following lines to
adhere to a max length of 80 characters in the given context.

Signed-off-by: Ryan Goulding <rgouldin@redhat.com>