### PR TITLE
rhel: Fix ovn-controller-vtep systemd-unit parameter

### DIFF
--- a/rhel/usr_lib_systemd_system_ovn-controller-vtep.service
+++ b/rhel/usr_lib_systemd_system_ovn-controller-vtep.service
@@ -43,7 +43,7 @@ Environment=VTEP_DB=unix:%t/openvswitch/db.sock
 EnvironmentFile=-/etc/sysconfig/ovn-controller-vtep
 ExecStart=/usr/bin/ovn-controller-vtep -vconsole:emer -vsyslog:err -vfile:info \
           --log-file=/var/log/ovn/ovn-controller-vtep.log \
-          --ovn-user=${OVN_USER_ID} \
+          --user=${OVN_USER_ID} \
           --no-chdir --pidfile=${OVN_RUNDIR}/ovn-controller-vtep.pid \
           --ovnsb-db=${OVN_DB} --vtep-db=${VTEP_DB}
 


### PR DESCRIPTION
In patch [1] running OVN services with supplying user was added.
Since ovn-controller-vtep is started directly from systemd unit,
unlike other OVN services (whitch use ovn-ctl script), user parameter
should be passed as `--user`, not `--ovn-user`.

[1] - cfb62bb ("rhel: Run ovn services with the 'openvswitch' user")

Signed-off-by: Vladislav Odintsov <odivlad@gmail.com>