### PR TITLE
Do not generate logical flows if lsp is not up

### DIFF
--- a/northd/ovn-northd.c
+++ b/northd/ovn-northd.c
@@ -4569,6 +4569,10 @@ build_lswitch_input_port_sec(struct hmap *ports, struct hmap *datapaths,
             continue;
         }
 
+        if (!lsp_is_up(op->nbsp) && strcmp(op->nbsp->type, "localnet")) {
+            continue;
+        }
+
         ds_clear(&match);
         ds_clear(&actions);
         ds_put_format(&match, "inport == %s", op->json_key);
@@ -4626,7 +4630,7 @@ build_lswitch_output_port_sec(struct hmap *ports, struct hmap *datapaths,
      * they don't even receive multicast or broadcast packets.
      */
     HMAP_FOR_EACH (op, key_node, ports) {
-        if (!op->nbsp || lsp_is_external(op->nbsp)) {
+        if (!op->nbsp || lsp_is_external(op->nbsp) || (!lsp_is_up(op->nbsp) && strcmp(op->nbsp->type, "localnet"))) {
             continue;
         }
 
@@ -6825,7 +6829,7 @@ build_lswitch_flows(struct hmap *datapaths, struct hmap *ports,
 
     /* Ingress table 19: Destination lookup, unicast handling (priority 50), */
     HMAP_FOR_EACH (op, key_node, ports) {
-        if (!op->nbsp || lsp_is_external(op->nbsp)) {
+        if (!op->nbsp || lsp_is_external(op->nbsp) || (!lsp_is_up(op->nbsp) && strcmp(op->nbsp->type, "localnet"))) {
             continue;
         }
 
@@ -9724,7 +9728,7 @@ build_lrouter_flows(struct hmap *datapaths, struct hmap *ports,
      * outport and an Ethernet address in eth.dst.
      */
     HMAP_FOR_EACH (op, key_node, ports) {
-        if (op->nbsp && !lsp_is_enabled(op->nbsp)) {
+        if (op->nbsp && (!lsp_is_enabled(op->nbsp) || (!lsp_is_up(op->nbsp) && strcmp(op->nbsp->type, "localnet")))) {
             continue;
         }
 


### PR DESCRIPTION
If the logical_switch_port is not in up state, we don't need to generate related logical_flow. In this way we can reduce the flow numbers in ovn-sb.

Signed-off-by: Mengxin Liu <liumengxinfly@gmail.com>