### PR TITLE
Use the correct command name in ovn-nbctl --help

### DIFF
--- a/utilities/ovn-nbctl.c
+++ b/utilities/ovn-nbctl.c
@@ -768,7 +768,7 @@ HA chassis group commands:\n\
   ha-chassis-group-list     List the HA chassis groups\n\
   ha-chassis-group-add-chassis GRP CHASSIS [PRIORITY] Adds an HA\
 chassis with optional PRIORITY to the HA chassis group GRP\n\
-  ha-chassis-group-del-chassis GRP CHASSIS Deletes the HA chassis\
+  ha-chassis-group-remove-chassis GRP CHASSIS Removes the HA chassis\
 CHASSIS from the HA chassis group GRP\n\
 \n\
 %s\


### PR DESCRIPTION
Command to remove the chassis from a ha chassis group is
"ha-chassis-group-remove-chassis". Use the correct function name in
"ovn-nbctl --help".

Signed-off-by: Kai Li <likailichee@gmail.com>
Reported-at: https://github.com/ovn-org/ovn/issues/58