### PR TITLE
Set DEFAULT_PROBE_INTERVAL_MSEC to 0 to avoid initial connection flapping

### DIFF
--- a/northd/ovn-northd.c
+++ b/northd/ovn-northd.c
@@ -100,8 +100,8 @@ static struct eth_addr svc_monitor_mac_ea;
 
 /* Default probe interval for NB and SB DB connections. */
 #define DEFAULT_PROBE_INTERVAL_MSEC 5000
-static int northd_probe_interval_nb = DEFAULT_PROBE_INTERVAL_MSEC;
-static int northd_probe_interval_sb = DEFAULT_PROBE_INTERVAL_MSEC;
+static int northd_probe_interval_nb = 0;
+static int northd_probe_interval_sb = 0;
 
 #define MAX_OVN_TAGS 4096
 


### PR DESCRIPTION
Set DEFAULT_PROBE_INTERVAL_MSEC to 0 to avoid initial connection flapping.

Before configured in northd_probe_interval value is actually applied to southbound and northbound database connections, both connections must be fully established, otherwise ovnnb_db_run() will return without retrieving configuration data from northbound DB. In cases when southbound database is big enough, default interval of 5 seconds will kill and retry the connection before it is fully established, no matter what is set in northd_probe_interval. Client reconnect will cause even more load to ovsdb-server and cause cascade effect, so northd can never stabilise. We have more than 2000 ports in our lab, and northd could not start before this patch, holding at 100% CPU utilisation both itself and ovsdb-server. 

After connections are established, any value in northd_probe_interval is applied correctly.

Signed-off-by: Renat Nurgaliyev <impleman@gmail.com>