### PR TITLE
Add protocol sctp for lb-add in manpage of ovn-nbctl

### DIFF
--- a/utilities/ovn-nbctl.8.xml
+++ b/utilities/ovn-nbctl.8.xml
@@ -935,10 +935,10 @@
 
         <p>
          The optional argument <var>protocol</var> must be either
-         <code>tcp</code> or <code>udp</code>.  This argument is useful when
-         a port number is provided as part of the <var>vip</var>.  If the
-         <var>protocol</var> is unspecified and a port number is provided as
-         part of the <var>vip</var>, OVN assumes the <var>protocol</var> to
+         <code>tcp</code>,  <code>udp</code> or <code>sctp</code>. This argument
+         is useful when a port number is provided as part of the <var>vip</var>.
+         If the <var>protocol</var> is unspecified and a port number is provided 
+         as part of the <var>vip</var>, OVN assumes the <var>protocol</var> to
          be <code>tcp</code>.
         </p>
 


### PR DESCRIPTION
Add protocol `sctp` for lb-add in manpage of ovn-nbctl
sctp is supported by lb,  but it has not been added into manpage of ovn-nbctl

Signed-off-by: Alexey Roytman <roytman@il.ibm.com>