### PR TITLE
system-ovn.at: Use 'ping6' instead of 'ping -6'

### DIFF
--- a/tests/system-ovn.at
+++ b/tests/system-ovn.at
@@ -284,13 +284,13 @@ ovn-nbctl --wait=hv sync
 OVS_WAIT_UNTIL([ovs-ofctl dump-flows br-int | grep 'nat(src=fd30::1)'])
 
 # 'alice1' should be able to ping 'foo1' directly.
-NS_CHECK_EXEC([alice1], [ping -6 -v -q -c 3 -i 0.3 -w 2 fd11::2 | FORMAT_PING], \
+NS_CHECK_EXEC([alice1], [ping6 -v -q -c 3 -i 0.3 -w 2 fd11::2 | FORMAT_PING], \
 [0], [dnl
 3 packets transmitted, 3 received, 0% packet loss, time 0ms
 ])
 
 # North-South DNAT: 'alice1' should also be able to ping 'foo1' via fd30::2
-NS_CHECK_EXEC([alice1], [ping -6 -q -c 3 -i 0.3 -w 2 fd30::2 | FORMAT_PING], \
+NS_CHECK_EXEC([alice1], [ping6 -q -c 3 -i 0.3 -w 2 fd30::2 | FORMAT_PING], \
 [0], [dnl
 3 packets transmitted, 3 received, 0% packet loss, time 0ms
 ])
@@ -303,7 +303,7 @@ icmpv6,orig=(src=fd21::2,dst=fd30::2,id=<cleared>,type=128,code=0),reply=(src=fd
 
 # South-North SNAT: 'bar1' pings 'alice1'. But 'alice1' receives traffic
 # from fd30::1
-NS_CHECK_EXEC([bar1], [ping -6 -q -c 3 -i 0.3 -w 2 fd21::2 | FORMAT_PING], \
+NS_CHECK_EXEC([bar1], [ping6 -q -c 3 -i 0.3 -w 2 fd21::2 | FORMAT_PING], \
 [0], [dnl
 3 packets transmitted, 3 received, 0% packet loss, time 0ms
 ])
@@ -324,7 +324,7 @@ ovn-nbctl --wait=hv sync
 AT_CHECK([ovs-appctl dpctl/flush-conntrack])
 
 # East-west DNAT and SNAT: 'bar1' pings fd30::2. 'foo1' receives it.
-NS_CHECK_EXEC([bar1], [ping -6 -q -c 3 -i 0.3 -w 2 fd30::2 | FORMAT_PING], \
+NS_CHECK_EXEC([bar1], [ping6 -q -c 3 -i 0.3 -w 2 fd30::2 | FORMAT_PING], \
 [0], [dnl
 3 packets transmitted, 3 received, 0% packet loss, time 0ms
 ])
@@ -960,7 +960,7 @@ ovn-nbctl --wait=hv sync
 OVS_WAIT_UNTIL([ovs-ofctl dump-flows br-int | grep 'nat(src=fd40::4)'])
 
 # North-South DNAT: 'alice1' should be able to ping 'foo1' via fd30::2
-NS_CHECK_EXEC([alice1], [ping -6 -q -c 3 -i 0.3 -w 2 fd40::2 | FORMAT_PING], \
+NS_CHECK_EXEC([alice1], [ping6 -q -c 3 -i 0.3 -w 2 fd40::2 | FORMAT_PING], \
 [0], [dnl
 3 packets transmitted, 3 received, 0% packet loss, time 0ms
 ])
@@ -978,7 +978,7 @@ icmpv6,orig=(src=fd30::3,dst=fd11::2,id=<cleared>,type=128,code=0),reply=(src=fd
 ])
 
 # North-South DNAT: 'bob1' should be able to ping 'foo1' via fd40::3
-NS_CHECK_EXEC([bob1], [ping -6 -q -c 3 -i 0.3 -w 2 fd40::3 | FORMAT_PING], \
+NS_CHECK_EXEC([bob1], [ping6 -q -c 3 -i 0.3 -w 2 fd40::3 | FORMAT_PING], \
 [0], [dnl
 3 packets transmitted, 3 received, 0% packet loss, time 0ms
 ])
@@ -997,7 +997,7 @@ icmpv6,orig=(src=fd30::4,dst=fd11::2,id=<cleared>,type=128,code=0),reply=(src=fd
 
 # South-North SNAT: 'bar1' pings 'bob1'. But 'bob1' receives traffic
 # from fd40::4
-NS_CHECK_EXEC([bar1], [ping -6 -q -c 3 -i 0.3 -w 2 fd30::4 | FORMAT_PING], \
+NS_CHECK_EXEC([bar1], [ping6 -q -c 3 -i 0.3 -w 2 fd30::4 | FORMAT_PING], \
 [0], [dnl
 3 packets transmitted, 3 received, 0% packet loss, time 0ms
 ])
@@ -1010,7 +1010,7 @@ icmpv6,orig=(src=fd12::2,dst=fd30::4,id=<cleared>,type=128,code=0),reply=(src=fd
 
 # South-North SNAT: 'foo1' pings 'alice1'. But 'alice1' receives traffic
 # from fd40::1
-NS_CHECK_EXEC([foo1], [ping -6 -q -c 3 -i 0.3 -w 2 fd30::3 | FORMAT_PING], \
+NS_CHECK_EXEC([foo1], [ping6 -q -c 3 -i 0.3 -w 2 fd30::3 | FORMAT_PING], \
 [0], [dnl
 3 packets transmitted, 3 received, 0% packet loss, time 0ms
 ])
@@ -1232,7 +1232,7 @@ NS_CHECK_EXEC([alice1], [ping -q -c 3 -i 0.3 -w 2 30.0.0.2 | FORMAT_PING], \
 ])
 
 # North-South DNAT: 'alice16' should be able to ping 'foo16' via fd30::2
-NS_CHECK_EXEC([alice16], [ping -6 -q -c 3 -i 0.3 -w 2 fd40::2 | FORMAT_PING], \
+NS_CHECK_EXEC([alice16], [ping6 -q -c 3 -i 0.3 -w 2 fd40::2 | FORMAT_PING], \
 [0], [dnl
 3 packets transmitted, 3 received, 0% packet loss, time 0ms
 ])
@@ -1265,7 +1265,7 @@ NS_CHECK_EXEC([bob1], [ping -q -c 3 -i 0.3 -w 2 30.0.0.3 | FORMAT_PING], \
 ])
 
 # North-South DNAT: 'bob16' should be able to ping 'foo16' via fd40::3
-NS_CHECK_EXEC([bob16], [ping -6 -q -c 3 -i 0.3 -w 2 fd40::3 | FORMAT_PING], \
+NS_CHECK_EXEC([bob16], [ping6 -q -c 3 -i 0.3 -w 2 fd40::3 | FORMAT_PING], \
 [0], [dnl
 3 packets transmitted, 3 received, 0% packet loss, time 0ms
 ])
@@ -1300,7 +1300,7 @@ NS_CHECK_EXEC([bar1], [ping -q -c 3 -i 0.3 -w 2 172.16.1.4 | FORMAT_PING], \
 ])
 # South-North SNAT: 'bar16' pings 'bob16'. But 'bob16' receives traffic
 # from fd40::4
-NS_CHECK_EXEC([bar16], [ping -6 -q -c 3 -i 0.3 -w 2 fd30::4 | FORMAT_PING], \
+NS_CHECK_EXEC([bar16], [ping6 -q -c 3 -i 0.3 -w 2 fd30::4 | FORMAT_PING], \
 [0], [dnl
 3 packets transmitted, 3 received, 0% packet loss, time 0ms
 ])
@@ -1324,7 +1324,7 @@ NS_CHECK_EXEC([foo1], [ping -q -c 3 -i 0.3 -w 2 172.16.1.3 | FORMAT_PING], \
 
 # South-North SNAT: 'foo16' pings 'alice16'. But 'alice16' receives traffic
 # from fd40::1
-NS_CHECK_EXEC([foo16], [ping -6 -q -c 3 -i 0.3 -w 2 fd30::3 | FORMAT_PING], \
+NS_CHECK_EXEC([foo16], [ping6 -q -c 3 -i 0.3 -w 2 fd30::3 | FORMAT_PING], \
 [0], [dnl
 3 packets transmitted, 3 received, 0% packet loss, time 0ms
 ])
@@ -3699,7 +3699,7 @@ ovn-nbctl --wait=hv sync
 OVS_WAIT_UNTIL([ovs-ofctl dump-flows br-int | grep 'nat(src=fd20::1)'])
 
 # North-South DNAT: 'alice1' pings 'foo1' using fd20::3
-NS_CHECK_EXEC([alice1], [ping -6 -q -c 3 -i 0.3 -w 2 fd20::3 | FORMAT_PING], \
+NS_CHECK_EXEC([alice1], [ping6 -q -c 3 -i 0.3 -w 2 fd20::3 | FORMAT_PING], \
 [0], [dnl
 3 packets transmitted, 3 received, 0% packet loss, time 0ms
 ])
@@ -3712,7 +3712,7 @@ icmpv6,orig=(src=fd20::2,dst=fd20::3,id=<cleared>,type=128,code=0),reply=(src=fd
 
 # South-North SNAT: 'foo2' pings 'alice1'. But 'alice1' receives traffic
 # from 172.16.1.4
-NS_CHECK_EXEC([foo2], [ping -6 -q -c 3 -i 0.3 -w 2 fd20::2 | FORMAT_PING], \
+NS_CHECK_EXEC([foo2], [ping6 -q -c 3 -i 0.3 -w 2 fd20::2 | FORMAT_PING], \
 [0], [dnl
 3 packets transmitted, 3 received, 0% packet loss, time 0ms
 ])
@@ -3727,7 +3727,7 @@ AT_CHECK([ovs-appctl dpctl/flush-conntrack])
 
 # South-North SNAT: 'bar1' pings 'alice1'. But 'alice1' receives traffic
 # from fd20::1
-NS_CHECK_EXEC([bar1], [ping -6 -q -c 3 -i 0.3 -w 2 fd20::2 | FORMAT_PING], \
+NS_CHECK_EXEC([bar1], [ping6 -q -c 3 -i 0.3 -w 2 fd20::2 | FORMAT_PING], \
 [0], [dnl
 3 packets transmitted, 3 received, 0% packet loss, time 0ms
 ])


### PR DESCRIPTION
Due to slight differences in behavior and/or output of some of the
utilities used by the tests when run on different distributions some
tests were failing when run on Ubuntu 16.04.

e.g.
2: ovn -- 2 LRs connected via LS, gateway router, SNAT and DNAT - IPv6 FAILED (system-ovn.at:284)
./system-ovn.at:284: ip netns exec alice1 sh << NS_EXEC_HEREDOC
ping -6 -v -q -c 3 -i 0.3 -w 2 fd11::2 | grep "transmitted" | sed 's/time.*ms$/time 0ms/'
NS_EXEC_HEREDOC
--- /dev/null	2021-05-20 20:28:34.600907021 -0700
+++ /home/code/ovn2021/tests/system-kmod-testsuite.dir/at-groups/2/stderr
2021-05-24 19:47:03.392672359 -0700
@@ -0,0 +1,5 @@
+ping: invalid option -- '6'
+Usage: ping [-aAbBdDfhLnOqrRUvV] [-c count] [-i interval] [-I interface]
+            [-m mark] [-M pmtudisc_option] [-l preload] [-p pattern] [-Q tos]
+            [-s packetsize] [-S sndbuf] [-t ttl] [-T timestamp_option]
+            [-w deadline] [-W timeout] [hop1 ...] destination
--- -	2021-05-24 19:47:03.398118664 -0700
+++ /home/code/ovn2021/tests/system-kmod-testsuite.dir/at-groups/2/stdout	2021-05-24 19:47:03.396672349 -0700
@@ -1,2 +1 @@
-3 packets transmitted, 3 received, 0% packet loss, time 0ms

Use 'ping6' instead of 'ping -6' to avoid failed tests.

Signed-off-by: zhang yanxian <zhangyanxian@pmlabs.com.cn>