### PR TITLE
Fix Broken Format in ovn-sbctl man page

### DIFF
--- a/utilities/ovn-sbctl.8.xml
+++ b/utilities/ovn-sbctl.8.xml
@@ -303,8 +303,8 @@
         </p>
 
         <p>
-          Without \fB\-\-may\-exist\fR, attempting to create a chassis that
-          exists is an error.  With \fB\-\-may\-exist\fR, this command does
+          Without <code>--may-exist</code>, attempting to create a chassis that
+          exists is an error.  With <code>--may-exist</code>, this command does
           nothing if <var>chassis</var> already exists.
         </p>
       </dd>


### PR DESCRIPTION
This commit fixes broken format in ovn-sbctl man page.

Signed-off-by: Vanou Ishii <ishii.vanou@fujitsu.com>