### PR TITLE
Add EXTRA_CONFIGURE_OPTS for debian build

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -30,7 +30,7 @@ override_dh_autoreconf:
 	dh_autoreconf $(DH_AS_NEEDED)
 
 override_dh_auto_configure:
-	dh_auto_configure -- --enable-ssl --enable-shared --with-ovs-source=${OVSDIR}
+	dh_auto_configure -- --enable-ssl --enable-shared --with-ovs-source=${OVSDIR} $(EXTRA_CONFIGURE_OPTS)
 
 override_dh_auto_test:
 ifeq (,$(filter nocheck,$(DEB_BUILD_OPTIONS)))


### PR DESCRIPTION
Just like ovs debian build, ovn debian build also need `EXTRA_CONFIGURE_OPTS` to config CFLAGS, jemalloc etc.