### PR TITLE
Set additional header in DNS message explicitly

### DIFF
--- a/controller/pinctrl.c
+++ b/controller/pinctrl.c
@@ -3023,8 +3023,9 @@ pinctrl_handle_dns_lookup(
     /* Set the response bit to 1 in the flags. */
     out_dns_header->lo_flag |= 0x80;
 
-    /* Set the answer RR. */
+    /* Set the answer RRs. */
     out_dns_header->ancount = htons(ancount);
+    out_dns_header->arcount = 0;
 
     /* Copy the Query section. */
     dp_packet_put(&pkt_out, dp_packet_data(pkt_in), dp_packet_size(pkt_in));


### PR DESCRIPTION
Some DNS Queries include an optional RR in the additional record section of
DNS, so simply copying the non-zero DNS Header for the additional records, but
not adding any leads to broken DNS packages.

This patch explicitly sets the additional records entry in the DNS header to 0.

Closes #114

Signed-off-by: Sven Haardiek <sven.haardiek@uni-muenster.de>