### PR TITLE
build tests with asan and ubsan together to reduce CI time.

### DIFF
--- a/.ci/linux-build.sh
+++ b/.ci/linux-build.sh
@@ -28,20 +28,14 @@ function configure_ovn()
 save_OPTS="${OPTS} $*"
 OPTS="${EXTRA_OPTS} ${save_OPTS}"
 
-# If AddressSanitizer or UdefinedBehaviorSanitizer is requested, enable it,
+# If AddressSanitizer and UndefinedBehaviorSanitizer are requested, enable them,
 # but only for OVN, not for OVS.  However, disable some optimizations for
 # OVS, to make sanitizer reports user friendly.
-if [ "$ASAN" ]; then
-    CFLAGS="-O1 -fno-omit-frame-pointer -fno-common"
-    CFLAGS_ASAN="-fsanitize=address"
-    OVN_CFLAGS="${OVN_CFLAGS} ${CFLAGS_ASAN}"
-fi
-
-if [ "$UBSAN" ]; then
+if [ "$SANITIZERS" ]; then
     # Use the default options configured in tests/atlocal.in, in UBSAN_OPTIONS.
-    CFLAGS="-O1 -fno-omit-frame-pointer -fno-common"
-    CFLAGS_UBSAN="-fsanitize=undefined"
-    OVN_CFLAGS="${OVN_CFLAGS} ${CFLAGS_UBSAN}"
+    CFLAGS="-O1 -fno-omit-frame-pointer -fno-common -g"
+    CFLAGS_SANITIZERS="-fsanitize=address,undefined"
+    OVN_CFLAGS="${OVN_CFLAGS} ${CFLAGS_SANITIZERS}"
 fi
 
 if [ "$CC" = "clang" ]; then

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,8 +20,8 @@ jobs:
       M32:         ${{ matrix.m32 }}
       OPTS:        ${{ matrix.opts }}
       TESTSUITE:   ${{ matrix.testsuite }}
-      ASAN:        ${{ matrix.asan }}
-      UBSAN:       ${{ matrix.ubsan }}
+      SANITIZERS:  ${{ matrix.sanitizers }}
+      CFLAGS:      ${{ matrix.cflags }}
 
     name: linux ${{ join(matrix.*, ' ') }}
     runs-on: ubuntu-20.04
@@ -41,10 +41,8 @@ jobs:
             testsuite:    system-test
           - compiler:     clang
             testsuite:    test
-            asan:         asan
-          - compiler:     clang
-            testsuite:    test
-            ubsan:        ubsan
+            sanitizers:   sanitizers
+            cflags:       -g
 
           - compiler:     gcc
             testsuite:    test

--- a/tests/atlocal.in
+++ b/tests/atlocal.in
@@ -211,10 +211,10 @@ export OVS_CTL_TIMEOUT
 
 # Add some default flags to make the tests run better under Address
 # Sanitizer, if it was used for the build.
-ASAN_OPTIONS=detect_leaks=1:abort_on_error=true:log_path=asan:$ASAN_OPTIONS
+ASAN_OPTIONS=detect_leaks=1:abort_on_error=true:log_path=sanitizers:$ASAN_OPTIONS
 export ASAN_OPTIONS
 
 # Add some default flags for UndefinedBehaviorSanitizer, if it was used
 # for the build.
-UBSAN_OPTIONS=print_stacktrace=1:halt_on_error=true:log_path=ubsan:$UBSAN_OPTIONS
+UBSAN_OPTIONS=print_stacktrace=1:halt_on_error=true:log_path=sanitizers:$UBSAN_OPTIONS
 export UBSAN_OPTIONS

--- a/tests/automake.mk
+++ b/tests/automake.mk
@@ -80,8 +80,7 @@ export ovs_srcdir
 check-local:
 	set $(SHELL) '$(TESTSUITE)' -C tests AUTOTEST_PATH=$(AUTOTEST_PATH); \
 	"$$@" $(TESTSUITEFLAGS) || \
-	(test -z "$$(find $(TESTSUITE_DIR) -name 'asan.*')" && \
-	 test -z "$$(find $(TESTSUITE_DIR) -name 'ubsan.*')" && \
+	(test -z "$$(find $(TESTSUITE_DIR) -name 'sanitizers.*')" && \
 	 test X'$(RECHECK)' = Xyes && "$$@" --recheck)
 
 # Python Coverage support.

--- a/tests/ovs-macros.at
+++ b/tests/ovs-macros.at
@@ -224,14 +224,9 @@ m4_divert_pop([PREPARE_TESTS])
 
 OVS_START_SHELL_HELPERS
 ovs_cleanup() {
-    if test "$(echo asan.*)" != 'asan.*'; then
-        echo "Address Sanitizer reported errors in:" asan.*
-        cat asan.*
-        AT_FAIL_IF([:])
-    fi
-    if test "$(echo ubsan.*)" != 'ubsan.*'; then
-        echo "Undefined Behavior Sanitizer reported errors in:" ubsan.*
-        cat ubsan.*
+    if test "$(echo sanitizers.*)" != 'sanitizers.*'; then
+        echo "Undefined Behavior Sanitizer or Address Sanitizer reported errors in:" sanitizers.*
+        cat sanitizers.*
         AT_FAIL_IF([:])
     fi
 }

--- a/utilities/ovn-dbctl.c
+++ b/utilities/ovn-dbctl.c
@@ -237,6 +237,10 @@ cleanup:
         }
         free(commands);
         if (error) {
+            for (int i = 0; i < argc; i++) {
+                free(argv_[i]);
+            }
+            free(argv_);
             ctl_fatal("%s", error);
         }
     }


### PR DESCRIPTION
Fixes #137 

It looks like ASAN and UBSAN work:

Test ASAN https://github.com/ovn-org/ovn/pull/140 results:
```
 ## ------------- ##
## Test results. ##
## ------------- ##
ERROR: 2420 tests were run,
1536 failed unexpectedly.
```

Test UBSAN #141 results:
```
## ------------- ##
## Test results. ##
## ------------- ##
ERROR: 2420 tests were run,
1537 failed unexpectedly.
```

But I don't know why this PR also failed:
```
ERROR: 2420 tests were run,
13 failed unexpectedly.
8 tests were skipped.
## -------------------------- ##
## testsuite.log was created. ##
## -------------------------- ##
Please send `tests/testsuite.log' and all information you think might help:
   To: <bugs@openvswitch.org>
   Subject: [ovn 22.06.90] testsuite: 963 964 965 966 967 968 969 970 1063 1064 1065 1066 1121 failed
```

Flaky tests?