### PR TITLE
cancel previous runs in the PR when you push new commits

### DIFF
--- a/.github/workflows/ovn-kubernetes.yml
+++ b/.github/workflows/ovn-kubernetes.yml
@@ -8,6 +8,10 @@ on:
   # Run Sunday at midnight
   - cron: '0 0 * * 0'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 env:
   GO_VERSION: "1.17.6"
   K8S_VERSION: v1.23.3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,10 @@ on:
     # Run Sunday at midnight
     - cron: '0 0 * * 0'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-linux:
     env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ on:
   push:
   pull_request:
   schedule:
-    # Run Sunday at midnight 111
+    # Run Sunday at midnight
     - cron: '0 0 * * 0'
 
 concurrency:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ on:
   push:
   pull_request:
   schedule:
-    # Run Sunday at midnight
+    # Run Sunday at midnight 111
     - cron: '0 0 * * 0'
 
 concurrency:


### PR DESCRIPTION
While implementing #139 I sometimes pushed several commits quickly and after that I noticed that previous run was still in progress and the most recent run was waiting in line.

I googled some solutions and I found the answer: https://stackoverflow.com/a/72408109/4544798

github docs: https://docs.github.com/en/actions/using-jobs/using-concurrency