### PR TITLE
ovn: Remove SBREC_TABLE_HA_CHASSIS ctl_table

### DIFF
--- a/utilities/ovn-sbctl.c
+++ b/utilities/ovn-sbctl.c
@@ -1431,9 +1431,6 @@ static const struct ctl_table_class tables[SBREC_N_TABLES] = {
     [SBREC_TABLE_HA_CHASSIS_GROUP].row_ids[0]
     = {&sbrec_ha_chassis_group_col_name, NULL, NULL},
 
-    [SBREC_TABLE_HA_CHASSIS].row_ids[0]
-    = {&sbrec_ha_chassis_col_chassis, NULL, NULL},
-
     [SBREC_TABLE_METER].row_ids[0]
     = {&sbrec_meter_col_name, NULL, NULL},
 


### PR DESCRIPTION
Fix bug that ovn-sbctl daemon process exit when list non-existed
ha_chassis.

Closes https://github.com/ovn-org/ovn/issues/150
Signed-off-by: Jun Gu <jun.gu@easystack.cn>
Signed-off-by: Weijia Wang <weijia.wang@easystack.cn>