### PR TITLE
utilities: Fix the bug that using help in ovn-ctl

### DIFF
--- a/utilities/ovn-ctl
+++ b/utilities/ovn-ctl
@@ -1118,6 +1118,8 @@ Default directories with "configure" option and environment variable override:
   user binaries: /usr/local/bin (--bindir, OVN_BINDIR)
   system binaries: /usr/local/sbin (--sbindir, OVN_SBINDIR)
 EOF
+
+    exit 0
 }
 
 set_defaults

--- a/utilities/ovn-trace.c
+++ b/utilities/ovn-trace.c
@@ -154,9 +154,15 @@ main(int argc, char *argv[])
         }
 
         if (ovsdb_idl_has_ever_connected(ovnsb_idl)) {
-            if (!already_read) {
-                already_read = true;
+            if (get_detach()) {
+                // When daemon mode, need to read latest data.
                 read_db();
+            } else {
+                // Non-daemon mode, just read once.
+                if (!already_read) {
+                    already_read = true;
+                    read_db();
+                }
             }
 
             daemonize_complete();


### PR DESCRIPTION
When using `ovn-ctl -h or --help` command, the information that `missing command name (use --help for help)` will be presented in the last line. Refer from ovs-ctl, run exit instruction after diplay usage information.

Signed-off-by: Jun Gu <jun.gu@easystack.cn>