### PR TITLE
utilities: Fix the bug that using help in ovn-ctl

### DIFF
--- a/utilities/ovn-ctl
+++ b/utilities/ovn-ctl
@@ -1118,6 +1118,8 @@ Default directories with "configure" option and environment variable override:
   user binaries: /usr/local/bin (--bindir, OVN_BINDIR)
   system binaries: /usr/local/sbin (--sbindir, OVN_SBINDIR)
 EOF
+
+    exit 0
 }
 
 set_defaults


### PR DESCRIPTION
When using `ovn-ctl -h or --help` command, the information that `missing command name (use --help for help)` will be presented in the last line. Refer from ovs-ctl, run exit instruction after diplay usage information.

Signed-off-by: Jun Gu <jun.gu@easystack.cn>