### PR TITLE
northd: add router broadcast option to logical switch

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -2,6 +2,11 @@ Post v23.03.0
 -------------
   - Enhance LSP.options:arp_proxy to support IPv6, configurable MAC
     addresses and CIDRs.
+  - Add LS.other_config:broadcast-arps-to-all-routers. If false then arp
+    requests are only send to Logical Routers on that Logical Switch if the
+    target mac address matches. Arp requests matching no Logical Router will
+    only be forwarded to non-router ports. Default is true which keeps the
+    existing behaviour of flooding these arp requests to all attached Ports.
 
 OVN v23.03.0 - 03 Mar 2023
 --------------------------

--- a/northd/northd.c
+++ b/northd/northd.c
@@ -9030,6 +9030,14 @@ build_lswitch_destination_lookup_bmcast(struct ovn_datapath *od,
             }
         }
 
+
+        if (!smap_get_bool(&od->nbs->other_config,
+                           "broadcast-arps-to-all-routers", true)) {
+            ovn_lflow_add(lflows, od, S_SWITCH_IN_L2_LKUP, 72,
+                        "eth.mcast && (arp.op == 1 || nd_ns)",
+                        "outport = \""MC_FLOOD_L2"\"; output;");
+        }
+
         ovn_lflow_add(lflows, od, S_SWITCH_IN_L2_LKUP, 70, "eth.mcast",
                       "outport = \""MC_FLOOD"\"; output;");
     }

--- a/northd/ovn-northd.8.xml
+++ b/northd/ovn-northd.8.xml
@@ -1881,6 +1881,13 @@ output;
       </li>
 
       <li>
+        A priority-72 flow that outputs all ARP requests and ND packets with
+        an Ethernet broadcast or multicast <code>eth.dst</code> to the
+        <code>MC_FLOOD_L2</code> multicast group if
+        <code>other_config:broadcast-arps-to-all-routers=true</code>.
+      </li>
+
+      <li>
         A priority-70 flow that outputs all packets with an Ethernet broadcast
         or multicast <code>eth.dst</code> to the <code>MC_FLOOD</code>
         multicast group.

--- a/ovn-nb.xml
+++ b/ovn-nb.xml
@@ -729,6 +729,18 @@
         localnet ports, fabric traffic that belongs to other tagged networks may
         be passed through such a port.
       </column>
+
+      <column name="other_config" key="broadcast-arps-to-all-routers"
+          type='{"type": "boolean"}'>
+        Determines whether arp requests and ipv6 neighbor solicitations should
+        be send to all routers and other switchports (default) or if it should
+        only be send to switchports where the ip/mac address is unknown.
+        Setting this to false can significantly reduce the load if the logical
+        switch can receive arp requests for ips it does not know about.
+        However setting this to false also means that garps are no longer
+        forwarded to all routers and therefor the mac bindings of the routers
+        are no longer updated.
+      </column>
     </group>
 
     <group title="Common Columns">

--- a/tests/ovn-northd.at
+++ b/tests/ovn-northd.at
@@ -6422,6 +6422,37 @@ AT_CLEANUP
 ])
 
 OVN_FOR_EACH_NORTHD_NO_HV([
+AT_SETUP([check broadcast-arps-to-all-routers option])
+ovn_start
+
+ovn-nbctl lr-add R1
+ovn-nbctl set logical_router R1 options:chassis=hv1
+ovn-nbctl lrp-add R1 R1-S1 02:ac:10:01:00:01 172.16.1.1/24
+
+ovn-nbctl ls-add S1
+ovn-nbctl lsp-add S1 S1-R1
+ovn-nbctl lsp-set-type S1-R1 router
+ovn-nbctl lsp-set-addresses S1-R1 "02:ac:10:01:00:01 172.16.1.1"
+ovn-nbctl --wait=sb lsp-set-options S1-R1 router-port=R1-S1 nat-addresses="router"
+ovn-nbctl lsp-add S1 S1-VIF
+ovn-nbctl lsp-set-addresses S1-VIF "02:ac:10:01:00:02 unkown"
+
+AT_CHECK([ovn-sbctl lflow-list S1 | grep ls_in_l2_lkup | grep -q 'match=(eth.mcast && (arp.op == 1 || nd_ns)), action=(outport = "_MC_flood_l2"; output;)'], [1])
+
+ovn-nbctl --wait=sb set Logical_Switch S1 \
+                    other_config:broadcast-arps-to-all-routers=false
+
+AT_CHECK([ovn-sbctl lflow-list S1 | grep ls_in_l2_lkup | grep -q 'match=(eth.mcast && (arp.op == 1 || nd_ns)), action=(outport = "_MC_flood_l2"; output;)'], [0])
+
+ovn-nbctl --wait=sb set Logical_Switch S1 \
+                    other_config:broadcast-arps-to-all-routers=true
+
+AT_CHECK([ovn-sbctl lflow-list S1 | grep ls_in_l2_lkup | grep -q 'match=(eth.mcast && (arp.op == 1 || nd_ns)), action=(outport = "_MC_flood_l2"; output;)'], [1])
+
+AT_CLEANUP
+])
+
+OVN_FOR_EACH_NORTHD_NO_HV([
 AT_SETUP([ACL log replies -- flows])
 
 set_acl_options() {


### PR DESCRIPTION
Assume the following setup:
```
+----------------+
| Logical Router |
| lr001          +-+
+----------------+ |
                |
+----------------+ |
| Logical Router | | +----------------+ +------------------+
| lr002          +-+-+ Logical Switch +-+ Phyiscal Network |
+----------------+ | | ls-ext         | |                  |
                | +----------------+ +------------------+
    ...          |
                |
+----------------+ |
| Logical Router | |
| lr300          +-+
+----------------+
```
If a arp request for the ip of lr001 on ls-ext is now received it is
only forwarded to that individual logical router.

If we however now receive a arp request for an ip not used by any of
lr001-lr300 we try to flood the arp request to all logical ports on ls-ext.
With around 300 routers this causes the arp request to be dropped after
some routers as we hit the 4096 resubmit limit.

In the most cases forwarding the arp requests to the logical routers is
pointless as we already know all of their ip addresses and they will
therefor not be able to answer the arp requests anyway.
Only if someone sends garps this is not the case. Then the request would
need to be flooded to all logical routers.

We can therefor not generally send these arp requests to MC_FLOOD_L2 as
this would break garps. As we can also not detect garps we need to leave
the solution to our users.

To do this we introduce the other_config `broadcast-arps-to-all-routers`
on logical switches (which is per default true). If set to false we add
a logical flow that forwards arp requests where we do not know a
specific target logical switch port to MC_FLOOD_L2, thereby bypassing
all logical routers.

Signed-off-by: Felix Huettner <felix.huettner@mail.schwarz>