### PR TITLE
Typo fix in the ovn-nbctl man page.

### DIFF
--- a/utilities/ovn-nbctl.8.xml
+++ b/utilities/ovn-nbctl.8.xml
@@ -1151,7 +1151,7 @@
     <h2>NAT Commands</h2>
 
     <dl>
-      <dt>[<code>--may-exist</code>] [<code>--stateless</code>] [<code>--gateway_port</code>=<var>GATEWAY_PORT</var>] <code>lr-nat-add</code> <var>router</var> <var>type</var> <var>external_ip</var> <var>logical_ip</var> [<var>logical_port</var> <var>external_mac</var>]</dt>
+      <dt>[<code>--may-exist</code>] [<code>--stateless</code>] [<code>--gateway-port</code>=<var>GATEWAY_PORT</var>] <code>lr-nat-add</code> <var>router</var> <var>type</var> <var>external_ip</var> <var>logical_ip</var> [<var>logical_port</var> <var>external_mac</var>]</dt>
       <dd>
         <p>
           Adds the specified NAT to <var>router</var>.


### PR DESCRIPTION
According to the ovn-nbctl man8 (NAT):
[--may-exist] [--stateless] [--gateway_port=GATEWAY_PORT]
lr-nat-add router type external_ip logical_ip [logical_port external_mac]

Result using man page syntax:
ovn-nbctl: unrecognized option '--gateway_port'

The option expected by the implementation is:
--gateway-port

Signed-off-by: Roberto Bartzen Acosta <rbartzen@gmail.com>