### PR TITLE
Correct ethtype referencing incorrect values

### DIFF
--- a/controller/physical.c
+++ b/controller/physical.c
@@ -703,22 +703,30 @@ put_replace_chassis_mac_flows(const struct simap *ct_zones,
     }
 }
 
-#define VLAN_80211AD_ETHTYPE 0x88a8
-#define VLAN_80211Q_ETHTYPE 0x8100
+#define VLAN_8021AD_ETHTYPE 0x88a8
+#define VLAN_8021Q_ETHTYPE 0x8100
 
 static void
 ofpact_put_push_vlan(struct ofpbuf *ofpacts, const struct smap *options, int tag)
 {
     const char *ethtype_opt = options ? smap_get(options, "ethtype") : NULL;
 
-    int ethtype = VLAN_80211Q_ETHTYPE;
+    int ethtype = VLAN_8021Q_ETHTYPE;
     if (ethtype_opt) {
-        if (!strcasecmp(ethtype_opt, "802.11ad")) {
-            ethtype = VLAN_80211AD_ETHTYPE;
-        } else if (strcasecmp(ethtype_opt, "802.11q")) {
+      if (!strcasecmp(ethtype_opt, "802.11ad") || !strcasecmp(ethtype_opt, "802.1ad")) {
+        ethtype = VLAN_8021AD_ETHTYPE;
+      } else if (!strcasecmp(ethtype_opt, "802.11q") || !strcasecmp(ethtype_opt, "802.1q")) {
+        ethtype = VLAN_8021Q_ETHTYPE;
+      } else {
             static struct vlog_rate_limit rl = VLOG_RATE_LIMIT_INIT(1, 1);
             VLOG_WARN_RL(&rl, "Unknown port ethtype: %s", ethtype_opt);
-        }
+      }
+      if (!strcasecmp(ethtype_opt, "802.11ad") || !strcasecmp(ethtype_opt, "802.11q")) {
+        static struct vlog_rate_limit rl = VLOG_RATE_LIMIT_INIT(1, 1);
+        VLOG_WARN_RL(&rl, "Using incorrect value  ethtype: %s for either "
+                          "802.1q or 802.1ad please correct this value",
+                          ethtype_opt);
+      }
     }
 
     struct ofpact_push_vlan *push_vlan;

--- a/ovn-nb.xml
+++ b/ovn-nb.xml
@@ -1124,7 +1124,7 @@
 
         <column name="options" key="ethtype">
           Optional. VLAN EtherType field value for encapsulating VLAN
-          headers. Supported values: 802.11q (default), 802.11ad.
+          headers. Supported values: 802.1q (default), 802.1ad.
         </column>
 
         <column name="options" key="localnet_learn_fdb"


### PR DESCRIPTION
documentation in OVN-NB in Logical_Switch_Port for Ethtype references incorrect values

"Supported values: 802.11q (default), 802.11ad."

This should be 802.1q and 802.1ad.

Correct this in the code and documentation. For now I logged as a warning that the incorrect value is used and maybe in the future the incorrect value could be removed.