### PR TITLE
tests: Ignore log setting extended ack support failed.

### DIFF
--- a/tests/ofproto-macros.at
+++ b/tests/ofproto-macros.at
@@ -288,6 +288,7 @@ check_logs () {
 /ovs_rcu.*blocked [[0-9]]* ms waiting for .* to quiesce/d
 /Dropped [[0-9]]* log messages/d
 /.*Trying to release unknown interface.*/d
+/setting extended ack support failed/d
 /|WARN|/p
 /|ERR|/p
 /|EMER|/p" ${logs}


### PR DESCRIPTION
The test error log 'setting extended ack support failed' in the test results may cause test failures. However, according to the OVS commit[1], this is not a critical issue, so we can safely ignore this log.

[1]https://github.com/openvswitch/ovs/commit/812164adefc716dd35c50c2101e8e60a15167635