### PR TITLE
northd: Fix issues for Forwarding_Group

### DIFF
--- a/northd/northd.c
+++ b/northd/northd.c
@@ -7929,6 +7929,9 @@ build_fwd_group_lflows(struct ovn_datapath *od, struct lflow_table *lflows,
             continue;
         }
 
+        ds_clear(&match);
+        ds_clear(&actions);
+
         /* ARP responder for the forwarding group's virtual IP */
         ds_put_format(&match, "arp.tpa == %s && arp.op == 1",
                       fwd_group->vip);
@@ -7959,9 +7962,9 @@ build_fwd_group_lflows(struct ovn_datapath *od, struct lflow_table *lflows,
             ds_put_cstr(&group_ports, "liveness=\"true\",");
         }
         ds_put_cstr(&group_ports, "childports=");
-        for (i = 0; i < (fwd_group->n_child_port - 1); ++i) {
+        for (size_t j = 0; j < (fwd_group->n_child_port - 1); ++j) {
             ds_put_format(&group_ports, "\"%s\",",
-                         fwd_group->child_port[i]);
+                         fwd_group->child_port[j]);
         }
         ds_put_format(&group_ports, "\"%s\"",
                       fwd_group->child_port[fwd_group->n_child_port - 1]);

--- a/tests/ovn.at
+++ b/tests/ovn.at
@@ -27054,7 +27054,14 @@ check ovs-vsctl add-port br-int vif3 -- set Interface vif3 external-ids:iface-id
 # Add a forwarding group on ls2 with lsp21 and lsp22 as child ports
 # virtual IP - 172.16.1.11, virtual MAC - 00:11:de:ad:be:ef
 check ovn-nbctl --wait=hv fwd-group-add fwd_grp1 ls2 172.16.1.11 00:11:de:ad:be:ef lsp21 lsp22
+check ovn-nbctl --wait=hv fwd-group-add fwd_grp2 ls2 172.16.2.11 00:22:de:ad:be:ef lsp21 lsp22
 
+# Check logical flow
+AT_CAPTURE_FILE([sbflows])
+ovn-sbctl dump-flows > sbflows
+AT_CHECK([grep ls_in_l2_lkup sbflows | grep fwd_group | wc -l], [0], [2
+])
+check ovn-nbctl --wait=hv fwd-group-del fwd_grp2
 # Check logical flow
 AT_CAPTURE_FILE([sbflows])
 ovn-sbctl dump-flows > sbflows


### PR DESCRIPTION
    The use of variables from the outer loop in the inner loop causes the outer loop to terminate prematurely.
    eg. LVS are three fwgs, fwg1(p1,p2,p3,p4),fwg2(p11,p22),fwg3(p31,p32),only fwg1 in logical_flows