### PR TITLE
[DNM] github: Add a permanent workaround for malformed /etc/hosts.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -118,6 +118,20 @@ jobs:
         sudo apt update
         sudo apt -y install linux-modules-extra-$(uname -r)
 
+    - name: fix /etc/hosts
+      # On multiple occasions GitHub added things to /etc/hosts that are not
+      # a correct syntax for this file causing test failures:
+      #   https://github.com/actions/runner-images/issues/3353
+      #   https://github.com/actions/runner-images/issues/12192
+      # Just clearing those out, if any.
+      run: |
+        set -x
+        cp /etc/hosts ./hosts.bak
+        sed -E -n \
+          '/^[[:space:]]*(#.*|[0-9a-fA-F:.]+([[:space:]]+[a-zA-Z0-9.-]+)+|)$/p' \
+          ./hosts.bak | sudo tee /etc/hosts
+        diff -u ./hosts.bak /etc/hosts || true
+
     - name: checkout
       if: github.event_name == 'push' || github.event_name == 'pull_request'
       uses: actions/checkout@v4


### PR DESCRIPTION
On two separate occasions GitHub added random garbage into the hosts file breaking our tests.  This change adds a permanent workaround for this kind of stuff.  It will remove everything that doesn't look like a correct syntax from the file.

The regex is not perfect, but it should be sufficient for most cases. It allows empty lines, comments and a valid 'IP NAME[ NAME]...' lines, where 'IP' resembles an IP address and the 'NAME' consists of valid DNS characters.  Under normal conditions the diff should always be empty.



(cherry picked from commit 8a3f17d769e005231e1b1127c18dc544e6473f65)