### PR TITLE
[WIP] [DNM] ci: Add permanent fix for /etc/hosts file.

### DIFF
--- a/.ci/linux-util.sh
+++ b/.ci/linux-util.sh
@@ -25,3 +25,13 @@ function set_containers_apparmor_profile()
     sed -i "s/^#apparmor_profile = \".*\"$/apparmor_profile = \"$profile\"/" \
         /usr/share/containers/containers.conf
 }
+
+function fix_etc_hosts()
+{
+    cp /etc/hosts ./hosts.bak
+    sed -E -n \
+      '/^[[:space:]]*(#.*|[0-9a-fA-F:.]+([[:space:]]+[a-zA-Z0-9.-]+)+|)$/p' \
+      ./hosts.bak | sudo tee /etc/hosts
+
+    diff -u ./hosts.bak /etc/hosts || true
+}

--- a/.github/workflows/ovn-fake-multinode-tests.yml
+++ b/.github/workflows/ovn-fake-multinode-tests.yml
@@ -104,6 +104,11 @@ jobs:
     - name: Check out ovn
       uses: actions/checkout@v4
 
+    - name: Fix /etc/hosts file
+      run: |
+        . .ci/linux-util.sh
+        fix_etc_hosts
+
     - name: install required dependencies
       run:  |
         sudo apt update || true

--- a/.github/workflows/ovn-kubernetes.yml
+++ b/.github/workflows/ovn-kubernetes.yml
@@ -101,6 +101,11 @@ jobs:
     - name: Check out ovn
       uses: actions/checkout@v4
 
+    - name: Fix /etc/hosts file
+      run: |
+        . .ci/linux-util.sh
+        fix_etc_hosts
+
     - name: Free up disk space
       run: |
         . .ci/linux-util.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -147,6 +147,11 @@ jobs:
             sort -V | tail -1)
       working-directory: ovs
 
+    - name: Fix /etc/hosts file
+      run: |
+        . .ci/linux-util.sh
+        fix_etc_hosts
+
     - name: image cache
       id: image_cache
       uses: actions/cache@v4


### PR DESCRIPTION
This is OVN adoptation of OvS patch:

On two separate occasions GitHub added random garbage into the hosts file breaking our tests.  This change adds a permanent workaround for this kind of stuff.  It will remove everything that doesn't look like a correct syntax from the file.

The regex is not perfect, but it should be sufficient for most cases. It allows empty lines, comments and a valid 'IP NAME[ NAME]...' lines, where 'IP' resembles an IP address and the 'NAME' consists of valid DNS characters.  Under normal conditions the diff should always be empty.