### PR TITLE
[WIP] ci: Add permanent fix for /etc/hosts file.

### DIFF
--- a/.ci/linux-util.sh
+++ b/.ci/linux-util.sh
@@ -25,3 +25,13 @@ function set_containers_apparmor_profile()
     sed -i "s/^#apparmor_profile = \".*\"$/apparmor_profile = \"$profile\"/" \
         /usr/share/containers/containers.conf
 }
+
+function fix_etc_hosts()
+{
+    cp /etc/hosts ./hosts.bak
+    sed -E -n \
+      '/^[[:space:]]*(#.*|[0-9a-fA-F:.]+([[:space:]]+[a-zA-Z0-9.-]+)+|)$/p' \
+      ./hosts.bak | sudo tee /etc/hosts
+
+    diff -u ./hosts.bak /etc/hosts || true
+}

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -29,6 +29,11 @@ jobs:
       - name: Install dependencies
         run: sudo apt install -y ${{ env.DEPENDENCIES }}
 
+      - name: Fix /etc/hosts file
+        run: |
+          . .ci/linux-util.sh
+          fix_etc_hosts
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
 

--- a/.github/workflows/ovn-fake-multinode-tests.yml
+++ b/.github/workflows/ovn-fake-multinode-tests.yml
@@ -56,6 +56,12 @@ jobs:
         sudo apt update || true
         sudo apt-get install -y podman
 
+    - name: Fix /etc/hosts file
+      run: |
+        . .ci/linux-util.sh
+        fix_etc_hosts
+      working-directory: ovn-fake-multinode/ovn
+
     - name: Build ovn-fake-multi-node ${{ matrix.cfg.branch }} image
       run: |
         set -x
@@ -108,6 +114,11 @@ jobs:
       run:  |
         sudo apt update || true
         sudo apt install -y ${{ env.dependencies }}
+
+    - name: Fix /etc/hosts file
+      run: |
+        . .ci/linux-util.sh
+        fix_etc_hosts
 
     - name: Free up disk space
       run: |

--- a/.github/workflows/ovn-kubernetes.yml
+++ b/.github/workflows/ovn-kubernetes.yml
@@ -37,6 +37,11 @@ jobs:
       with:
         submodules: recursive
 
+    - name: Fix /etc/hosts file
+      run: |
+        . .ci/linux-util.sh
+        fix_etc_hosts
+
     - name: Check out ovn-kubernetes
       uses: actions/checkout@v4
       with:
@@ -100,6 +105,11 @@ jobs:
 
     - name: Check out ovn
       uses: actions/checkout@v4
+
+    - name: Fix /etc/hosts file
+      run: |
+        . .ci/linux-util.sh
+        fix_etc_hosts
 
     - name: Free up disk space
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,6 +37,11 @@ jobs:
       - name: Install dependencies
         run: sudo apt install -y ${{ env.DEPENDENCIES }}
 
+      - name: Fix /etc/hosts file
+        run: |
+          . .ci/linux-util.sh
+          fix_etc_hosts
+
       - name: Choose image distro
         if: github.event_name == 'push' || github.event_name == 'pull_request'
         run: |
@@ -146,6 +151,11 @@ jobs:
           $(git branch -a -l '*branch-*' | sed 's/remotes\/origin\///' | \
             sort -V | tail -1)
       working-directory: ovs
+
+    - name: Fix /etc/hosts file
+      run: |
+        . .ci/linux-util.sh
+        fix_etc_hosts
 
     - name: image cache
       id: image_cache
@@ -258,6 +268,11 @@ jobs:
           sed -e 's/@VERSION@/0.0.1/' rhel/ovn-fedora.spec.in \
           > /tmp/ovn.spec
           dnf builddep -y /tmp/ovn.spec
+
+      - name: Fix /etc/hosts file
+        run: |
+          . .ci/linux-util.sh
+          fix_etc_hosts
 
       - name: configure OvS
         run: ./boot.sh && ./configure


### PR DESCRIPTION
This is OVN adoptation of OvS patch:

On two separate occasions GitHub added random garbage into the hosts file breaking our tests.  This change adds a permanent workaround for this kind of stuff.  It will remove everything that doesn't look like a correct syntax from the file.

The regex is not perfect, but it should be sufficient for most cases. It allows empty lines, comments and a valid 'IP NAME[ NAME]...' lines, where 'IP' resembles an IP address and the 'NAME' consists of valid DNS characters.  Under normal conditions the diff should always be empty.