### PR TITLE
debian: Source ovn-lib from ovn-host init script.

### DIFF
--- a/debian/ovn-host.init
+++ b/debian/ovn-host.init
@@ -18,7 +18,7 @@ test -x /usr/share/ovn/scripts/ovn-ctl || exit 0
 _SYSTEMCTL_SKIP_REDIRECT=yes
 SYSTEMCTL_SKIP_REDIRECT=yes
 
-. /usr/share/ovn/scripts/ovs-lib
+. /usr/share/ovn/scripts/ovn-lib
 if [ -e /etc/default/ovn-host ]; then
     . /etc/default/ovn-host
 fi


### PR DESCRIPTION
The ovn-host init script currently sources
/usr/share/ovn/scripts/ovs-lib, but ovn-common does not install that file.  The OVN helper installed by ovn-common is
/usr/share/ovn/scripts/ovn-lib.

The central init script already sources the installed OVN helper from /usr/share/ovn/scripts/ovn-lib.  Use the same helper from ovn-host so both init scripts are consistent and only reference files installed by the OVN package.

Without this change, ovn-host can fail during package configuration when postinst restarts the service:

    /etc/init.d/ovn-host: 21: .: cannot open
    /usr/share/ovn/scripts/ovs-lib: No such file

Reported-at: https://github.com/ovn-org/ovn/issues/314