### PR TITLE
northd: Treat HA group membership as BFD eligibility

### DIFF
--- a/controller/pinctrl.c
+++ b/controller/pinctrl.c
@@ -356,6 +356,7 @@ static void notify_pinctrl_handler(void);
 
 static bool bfd_monitor_should_inject(void);
 static void bfd_monitor_wait(long long int timeout);
+static void bfd_monitor_reconcile_wait(void);
 static void bfd_monitor_init(void);
 static void bfd_monitor_destroy(void);
 static void bfd_monitor_send_msg(struct rconn *swconn, long long int *bfd_time)
@@ -4753,6 +4754,7 @@ pinctrl_wait(struct ovsdb_idl_txn *ovnsb_idl_txn)
     if (ovnsb_idl_txn) {
         wait_controller_event();
         wait_put_vport_bindings();
+        bfd_monitor_reconcile_wait();
         seq_wait(pinctrl_main_seq, main_seq);
     }
     wait_activated_ports();
@@ -7584,6 +7586,8 @@ struct bfd_entry {
     uint32_t detection_timeout;
     long long int last_rx;
     long long int next_tx;
+    /* Earliest time for the next SB status reconciliation attempt. */
+    long long int next_reconcile;
 };
 
 static void
@@ -7651,6 +7655,21 @@ bfd_monitor_wait(long long int timeout)
 {
     if (!hmap_is_empty(&bfd_monitor_map)) {
         poll_timer_wait_until(timeout);
+    }
+}
+
+/* Register reconciliation deadlines with the main controller thread.  BFD
+ * packet transmission is handled by the pinctrl handler thread, but SB IDL
+ * transactions are owned by the main thread. */
+static void
+bfd_monitor_reconcile_wait(void)
+{
+    struct bfd_entry *entry;
+
+    HMAP_FOR_EACH (entry, node, &bfd_monitor_map) {
+        if (entry->next_reconcile) {
+            poll_timer_wait_until(entry->next_reconcile);
+        }
     }
 }
 
@@ -8173,8 +8192,34 @@ bfd_monitor_run(struct ovsdb_idl_txn *ovnsb_idl_txn,
             if (entry->state == BFD_STATE_DOWN) {
                 entry->remote_disc = 0;
             }
+            sbrec_bfd_verify_status(bt);
             sbrec_bfd_set_status(bt, bfd_get_status(entry->state));
             entry->change_state = false;
+        }
+
+        /* Reconcile the SB status with the local session state.  The
+         * state machine only writes the status out on transitions (see
+         * the change_state branch above), so a divergent SB value would
+         * otherwise persist until the next transition, e.g. if the row
+         * held a stale status when the session was created or if an
+         * external client rewrote the column.  Skip "admin_down": it is
+         * an administrative override written by northd/CMS, not a state
+         * machine product, and the branches above already move the local
+         * session in and out of BFD_STATE_ADMIN_DOWN to honor it.
+         * Rate limit the attempts so that a write repeatedly rejected by
+         * the server, e.g. by RBAC, does not busy loop the main loop. */
+        if (ovnsb_idl_txn && !entry->change_state &&
+            entry->state != BFD_STATE_ADMIN_DOWN &&
+            cur_time >= entry->next_reconcile &&
+            strcmp(bt->status, "admin_down") &&
+            strcmp(bt->status, bfd_get_status(entry->state))) {
+            sbrec_bfd_verify_status(bt);
+            sbrec_bfd_set_status(bt, bfd_get_status(entry->state));
+            entry->next_reconcile = cur_time + BFD_UPDATE_TIMEOUT;
+        } else if (entry->state == BFD_STATE_ADMIN_DOWN ||
+                   !strcmp(bt->status, "admin_down") ||
+                   !strcmp(bt->status, bfd_get_status(entry->state))) {
+            entry->next_reconcile = 0;
         }
         bfd_monitor_check_sb_conf(bt, entry);
         entry->erase = false;

--- a/northd/en-northd.c
+++ b/northd/en-northd.c
@@ -566,6 +566,30 @@ bfd_sync_routes_change_handler(struct engine_node *node,
     return EN_HANDLED_UNCHANGED;
 }
 
+enum engine_input_handler_result
+bfd_sync_sb_port_binding_change_handler(struct engine_node *node, void *data)
+{
+    struct bfd_sync_data *bfd_sync_data = data;
+    struct northd_data *northd_data = engine_get_input_data("northd", node);
+    const struct sbrec_port_binding_table *sbrec_port_binding_table =
+        EN_OVSDB_GET(engine_get_input("SB_port_binding", node));
+
+    /* bfd_table_sync() derives the chassis that runs a BFD session (and
+     * with it the NB/SB BFD "status" and the SB BFD "chassis_name") from
+     * the Port_Binding of the session's logical port and of its
+     * chassisredirect twin.  If a chassis binding of such a port changed
+     * (e.g. the chassis running the session went away and the binding
+     * was released), fall back to recompute; all other Port_Binding
+     * changes are irrelevant to BFD. */
+    if (!bfd_sync_handle_sb_port_binding_changes(sbrec_port_binding_table,
+                                                 &northd_data->lr_ports,
+                                                 &bfd_sync_data->bfd_ports)) {
+        return EN_UNHANDLED;
+    }
+
+    return EN_HANDLED_UNCHANGED;
+}
+
 enum engine_node_state
 en_bfd_sync_run(struct engine_node *node, void *data)
 {

--- a/northd/en-northd.h
+++ b/northd/en-northd.h
@@ -58,6 +58,9 @@ bfd_sync_northd_change_handler(struct engine_node *node,
 enum engine_input_handler_result
 bfd_sync_routes_change_handler(struct engine_node *node,
                                void *data OVS_UNUSED);
+enum engine_input_handler_result
+bfd_sync_sb_port_binding_change_handler(struct engine_node *node,
+                                        void *data);
 
 enum engine_node_state en_bfd_sync_run(struct engine_node *node, void *data);
 void en_bfd_sync_cleanup(void *data OVS_UNUSED);

--- a/northd/inc-proc-northd.c
+++ b/northd/inc-proc-northd.c
@@ -347,6 +347,7 @@ void inc_proc_northd_init(struct ovsdb_idl_loop *nb,
     engine_add_input(&en_bfd_sync, &en_northd, bfd_sync_northd_change_handler);
     engine_add_input(&en_bfd_sync, &en_sb_port_binding,
                      bfd_sync_sb_port_binding_change_handler);
+    engine_add_input(&en_bfd_sync, &en_sb_ha_chassis_group, NULL);
 
     engine_add_input(&en_ecmp_nexthop, &en_global_config, NULL);
     engine_add_input(&en_ecmp_nexthop, &en_routes, NULL);

--- a/northd/inc-proc-northd.c
+++ b/northd/inc-proc-northd.c
@@ -345,6 +345,8 @@ void inc_proc_northd_init(struct ovsdb_idl_loop *nb,
     engine_add_input(&en_bfd_sync, &en_routes, bfd_sync_routes_change_handler);
     engine_add_input(&en_bfd_sync, &en_route_policies, NULL);
     engine_add_input(&en_bfd_sync, &en_northd, bfd_sync_northd_change_handler);
+    engine_add_input(&en_bfd_sync, &en_sb_port_binding,
+                     bfd_sync_sb_port_binding_change_handler);
 
     engine_add_input(&en_ecmp_nexthop, &en_global_config, NULL);
     engine_add_input(&en_ecmp_nexthop, &en_routes, NULL);

--- a/northd/northd.c
+++ b/northd/northd.c
@@ -11955,6 +11955,23 @@ bfd_get_connection_status(const struct nbrec_bfd *nb_bt,
     return bfd_rp ? bfd_rp->status : bfd_sr->status;
 }
 
+/* Returns the chassis that runs the BFD session for the logical router
+ * port 'op', mirroring the ownership rule implemented by bfd_monitor_run()
+ * in controller/pinctrl.c: ovn-controller runs the session if the
+ * chassisredirect twin of 'op' is bound to the chassis or if 'op' itself
+ * (an "l3gateway" port) is bound to the chassis.  Returns NULL if there is
+ * no currently bound BFD owner. */
+static const struct sbrec_chassis *
+bfd_get_session_chassis(const struct ovn_port *op)
+{
+    if (op->cr_port && op->cr_port->sb) {
+        return op->cr_port->sb->chassis;
+    }
+
+    return (op->sb && !strcmp(op->sb->type, "l3gateway"))
+           ? op->sb->chassis : NULL;
+}
+
 void
 bfd_table_sync(struct ovsdb_idl_txn *ovnsb_txn,
                const struct nbrec_bfd_table *nbrec_bfd_table,
@@ -11996,10 +12013,24 @@ bfd_table_sync(struct ovsdb_idl_txn *ovnsb_txn,
             continue;
         }
 
+        const struct sbrec_chassis *chassis = bfd_get_session_chassis(op);
+
         nbrec_bfd_set_status(nb_bt,
                              bfd_get_connection_status(nb_bt,
                                                        rp_bfd_connections,
                                                        sr_bfd_connections));
+
+        if (!chassis && strcmp(nb_bt->status, "admin_down") &&
+            strcmp(nb_bt->status, "down")) {
+            /* No chassis currently owns the BFD session for this port, e.g.
+             * the chassis that was running it disappeared and no other
+             * chassis took the port over.  ovn-controller is the only writer of
+             * the SB BFD status, so mark the session down from here;
+             * otherwise a stale "up" status would keep BFD-monitored
+             * static routes pointing at a dead next hop. */
+            nbrec_bfd_set_status(nb_bt, "down");
+        }
+
         if (!bfd_e->sb_bt) {
             int udp_src = bfd_get_unused_port(bfd_src_ports);
             if (udp_src < 0) {
@@ -12013,8 +12044,8 @@ bfd_table_sync(struct ovsdb_idl_txn *ovnsb_txn,
             sbrec_bfd_set_disc(sb_bt, 1 + random_uint32());
             sbrec_bfd_set_src_port(sb_bt, udp_src);
             sbrec_bfd_set_status(sb_bt, nb_bt->status);
-            if (op->sb->chassis) {
-                sbrec_bfd_set_chassis_name(sb_bt, op->sb->chassis->name);
+            if (chassis) {
+                sbrec_bfd_set_chassis_name(sb_bt, chassis->name);
             }
 
             int min_tx = nb_bt->n_min_tx ? nb_bt->min_tx[0] : BFD_DEF_MINTX;
@@ -12025,7 +12056,14 @@ bfd_table_sync(struct ovsdb_idl_txn *ovnsb_txn,
                                               : BFD_DEF_DETECT_MULT;
             sbrec_bfd_set_detect_mult(sb_bt, d_mult);
         } else {
-            if (strcmp(bfd_e->sb_bt->status, nb_bt->status)) {
+            if (!chassis && strcmp(nb_bt->status, "admin_down")) {
+                /* NB status has already been set to "down" above; make
+                 * the SB status follow it instead of syncing the stale
+                 * SB status back into the NB. */
+                if (strcmp(bfd_e->sb_bt->status, "down")) {
+                    sbrec_bfd_set_status(bfd_e->sb_bt, "down");
+                }
+            } else if (strcmp(bfd_e->sb_bt->status, nb_bt->status)) {
                 if (!strcmp(nb_bt->status, "admin_down") ||
                     !strcmp(bfd_e->sb_bt->status, "admin_down")) {
                     sbrec_bfd_set_status(bfd_e->sb_bt, nb_bt->status);
@@ -12035,10 +12073,10 @@ bfd_table_sync(struct ovsdb_idl_txn *ovnsb_txn,
             }
 
             build_bfd_update_sb_conf(nb_bt, bfd_e->sb_bt);
-            if (op->sb->chassis && !strcmp(op->sb->chassis->name,
-                                           bfd_e->sb_bt->chassis_name)) {
-                sbrec_bfd_set_chassis_name(bfd_e->sb_bt,
-                                           op->sb->chassis->name);
+
+            const char *chassis_name = chassis ? chassis->name : "";
+            if (strcmp(chassis_name, bfd_e->sb_bt->chassis_name)) {
+                sbrec_bfd_set_chassis_name(bfd_e->sb_bt, chassis_name);
             }
         }
 
@@ -12087,6 +12125,50 @@ build_bfd_map(const struct nbrec_bfd_table *nbrec_bfd_table,
         }
         bfd_e->nb_bt = nb_bt;
     }
+}
+
+/* Returns false if a tracked SB Port_Binding change modified the chassis
+ * a BFD session runs on, i.e. the "chassis" column of a Port_Binding
+ * whose logical port (or, for a chassisredirect port, whose distributed
+ * port) has a BFD session changed.  bfd_table_sync() then needs to run
+ * again to reevaluate the session ownership: e.g. the chassis running
+ * the session went away and the binding was released, in which case the
+ * NB/SB BFD status must be marked "down".  Returns true if none of the
+ * tracked changes are relevant to BFD. */
+bool
+bfd_sync_handle_sb_port_binding_changes(
+    const struct sbrec_port_binding_table *sbrec_port_binding_table,
+    const struct hmap *lr_ports, const struct sset *bfd_ports)
+{
+    const struct sbrec_port_binding *pb;
+    SBREC_PORT_BINDING_TABLE_FOR_EACH_TRACKED (pb,
+                                               sbrec_port_binding_table) {
+        if (sbrec_port_binding_is_new(pb) ||
+            sbrec_port_binding_is_deleted(pb)) {
+            continue;
+        }
+
+        if (!sbrec_port_binding_is_updated(pb,
+                                           SBREC_PORT_BINDING_COL_CHASSIS)) {
+            continue;
+        }
+
+        const struct ovn_port *op = ovn_port_find(lr_ports,
+                                                  pb->logical_port);
+        if (!op) {
+            continue;
+        }
+
+        if (op->primary_port) {
+            op = op->primary_port;
+        }
+
+        if (bfd_is_port_running(bfd_ports, op->key)) {
+            return false;
+        }
+    }
+
+    return true;
 }
 
 void

--- a/northd/northd.c
+++ b/northd/northd.c
@@ -11955,21 +11955,51 @@ bfd_get_connection_status(const struct nbrec_bfd *nb_bt,
     return bfd_rp ? bfd_rp->status : bfd_sr->status;
 }
 
+/* Returns true if 'chassis' is an eligible member of 'pb''s HA chassis
+ * group.  A Port_Binding without an HA chassis group has no additional
+ * eligibility constraint. */
+static bool
+bfd_chassis_is_eligible(const struct sbrec_port_binding *pb,
+                        const struct sbrec_chassis *chassis)
+{
+    if (!pb->ha_chassis_group) {
+        return true;
+    }
+
+    for (size_t i = 0; i < pb->ha_chassis_group->n_ha_chassis; i++) {
+        if (pb->ha_chassis_group->ha_chassis[i]->chassis == chassis) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
 /* Returns the chassis that runs the BFD session for the logical router
  * port 'op', mirroring the ownership rule implemented by bfd_monitor_run()
  * in controller/pinctrl.c: ovn-controller runs the session if the
  * chassisredirect twin of 'op' is bound to the chassis or if 'op' itself
- * (an "l3gateway" port) is bound to the chassis.  Returns NULL if there is
- * no currently bound BFD owner. */
+ * (an "l3gateway" port) is bound to the chassis.  A bound chassis is
+ * not a valid owner when it is no longer a member of the Port_Binding's HA
+ * chassis group.  Returns NULL if there is no currently bound eligible
+ * owner. */
 static const struct sbrec_chassis *
 bfd_get_session_chassis(const struct ovn_port *op)
 {
+    const struct sbrec_port_binding *pb = NULL;
+
     if (op->cr_port && op->cr_port->sb) {
-        return op->cr_port->sb->chassis;
+        pb = op->cr_port->sb;
+    } else if (op->sb && !strcmp(op->sb->type, "l3gateway")) {
+        pb = op->sb;
     }
 
-    return (op->sb && !strcmp(op->sb->type, "l3gateway"))
-           ? op->sb->chassis : NULL;
+    if (!pb || !pb->chassis ||
+        !bfd_chassis_is_eligible(pb, pb->chassis)) {
+        return NULL;
+    }
+
+    return pb->chassis;
 }
 
 void

--- a/northd/northd.h
+++ b/northd/northd.h
@@ -1030,6 +1030,9 @@ void bfd_table_sync(struct ovsdb_idl_txn *, const struct nbrec_bfd_table *,
                     struct sset *);
 void build_bfd_map(const struct nbrec_bfd_table *,
                    const struct sbrec_bfd_table *, struct hmap *);
+bool bfd_sync_handle_sb_port_binding_changes(
+    const struct sbrec_port_binding_table *,
+    const struct hmap *lr_ports, const struct sset *bfd_ports);
 
 void build_ic_learned_svc_monitors_map(
     struct hmap *ic_learned_svc_monitors_map,

--- a/ovn-nb.xml
+++ b/ovn-nb.xml
@@ -6704,6 +6704,13 @@ or
             </li>
           </ul>
         </p>
+        <p>
+          The status is normally reported by the <code>ovn-controller</code>
+          running the BFD session.  If no chassis currently owns the session
+          for the logical port (e.g. the gateway-port binding was released),
+          <code>ovn-northd</code> sets the status of a session that is not
+          <code>admin_down</code> to <code>down</code>.
+        </p>
       </column>
     </group>
   </table>

--- a/ovn-nb.xml
+++ b/ovn-nb.xml
@@ -6706,8 +6706,9 @@ or
         </p>
         <p>
           The status is normally reported by the <code>ovn-controller</code>
-          running the BFD session.  If no chassis currently owns the session
-          for the logical port (e.g. the gateway-port binding was released),
+          running the BFD session.  If no eligible chassis currently owns the
+          session for the logical port (e.g. the binding was released or its
+          stale owner is no longer a member of the port's HA chassis group),
           <code>ovn-northd</code> sets the status of a session that is not
           <code>admin_down</code> to <code>down</code>.
         </p>

--- a/ovn-sb.xml
+++ b/ovn-sb.xml
@@ -5413,7 +5413,9 @@ tcp.flags = RST;
       <column name="chassis_name">
         The name of the chassis running the BFD session.  For a
         distributed gateway port this is the chassis its chassisredirect
-        port is bound to.  Empty when there is no currently bound owner.
+        port is bound to.  Empty when there is no currently bound eligible
+        owner, including when the bound chassis is not a member of the port's
+        HA chassis group.
       </column>
 
       <column name="options">

--- a/ovn-sb.xml
+++ b/ovn-sb.xml
@@ -5411,7 +5411,9 @@ tcp.flags = RST;
       </column>
 
       <column name="chassis_name">
-        The name of the chassis where the logical port is bound.
+        The name of the chassis running the BFD session.  For a
+        distributed gateway port this is the chassis its chassisredirect
+        port is bound to.  Empty when there is no currently bound owner.
       </column>
 
       <column name="options">

--- a/tests/ovn-inc-proc-graph-dump.at
+++ b/tests/ovn-inc-proc-graph-dump.at
@@ -164,6 +164,7 @@ digraph "Incremental-Processing-Engine" {
 	routes -> bfd_sync [[label="bfd_sync_routes_change_handler"]];
 	route_policies -> bfd_sync [[label=""]];
 	northd -> bfd_sync [[label="bfd_sync_northd_change_handler"]];
+	SB_port_binding -> bfd_sync [[label="bfd_sync_sb_port_binding_change_handler"]];
 	SB_learned_route [[style=filled, shape=box, fillcolor=white, label="SB_learned_route"]];
 	learned_route_sync [[style=filled, shape=box, fillcolor=white, label="learned_route_sync"]];
 	SB_learned_route -> learned_route_sync [[label="learned_route_sync_sb_learned_route_change_handler"]];

--- a/tests/ovn-inc-proc-graph-dump.at
+++ b/tests/ovn-inc-proc-graph-dump.at
@@ -165,6 +165,7 @@ digraph "Incremental-Processing-Engine" {
 	route_policies -> bfd_sync [[label=""]];
 	northd -> bfd_sync [[label="bfd_sync_northd_change_handler"]];
 	SB_port_binding -> bfd_sync [[label="bfd_sync_sb_port_binding_change_handler"]];
+	SB_ha_chassis_group -> bfd_sync [[label=""]];
 	SB_learned_route [[style=filled, shape=box, fillcolor=white, label="SB_learned_route"]];
 	learned_route_sync [[style=filled, shape=box, fillcolor=white, label="learned_route_sync"]];
 	SB_learned_route -> learned_route_sync [[label="learned_route_sync_sb_learned_route_change_handler"]];

--- a/tests/ovn-northd.at
+++ b/tests/ovn-northd.at
@@ -4419,8 +4419,15 @@ wait_row_count bfd 5
 
 # Simulate BFD up in Southbound for an automatically created entry.
 # This entry is referenced so the state in the Northbound should also
-# become "up".
+# become "up".  A BFD session can only be up if some chassis runs it, so
+# turn r0-sw2 into a gateway port and bind its chassisredirect port
+# first, like ovn-controller would do.
 wait_column down nb:bfd status logical_port=r0-sw2
+check ovn-sbctl chassis-add hv1 geneve 127.0.0.1
+check ovn-nbctl --wait=sb lrp-set-gateway-chassis r0-sw2 hv1 10
+hv1_uuid=$(fetch_column chassis _uuid name=hv1)
+check ovn-sbctl set port_binding cr-r0-sw2 chassis=$hv1_uuid
+wait_column hv1 bfd chassis_name logical_port=r0-sw2
 bfd2_uuid=$(fetch_column bfd _uuid logical_port=r0-sw2)
 check ovn-sbctl set bfd $bfd2_uuid status=up
 wait_column up nb:bfd status logical_port=r0-sw2
@@ -4463,6 +4470,122 @@ AT_CHECK([ovn-nbctl list logical_router_policy | sed s/,//g | grep -q "$bfd_rout
 # recompute does not crash northd.
 check ovn-nbctl --wait=sb lrp-del r0-sw2
 check ovn-nbctl --wait=sb sync
+
+OVN_CLEANUP_NORTHD
+AT_CLEANUP
+])
+
+OVN_FOR_EACH_NORTHD_NO_HV([
+AT_SETUP([BFD sessions marked down when no chassis can run them])
+AT_KEYWORDS([northd-bfd])
+ovn_start
+
+check ovn-sbctl chassis-add hv1 geneve 127.0.0.1
+
+check ovn-nbctl lr-add r0
+check ovn-nbctl lrp-add r0 r0-public 00:00:20:20:12:13 172.16.0.1/24
+check ovn-nbctl ls-add public
+check ovn-nbctl lsp-add-router-port public public-r0 r0-public
+check ovn-nbctl --wait=sb lrp-set-gateway-chassis r0-public hv1 10
+
+bfd_uuid=$(ovn-nbctl create bfd logical_port=r0-public dst_ip=172.16.0.50)
+check test -n "$bfd_uuid"
+check ovn-nbctl --bfd=$bfd_uuid lr-route-add r0 100.0.0.0/8 172.16.0.50
+
+# The gateway port is not bound to any chassis yet, so no chassis runs
+# the BFD session: both NB and SB status must be "down".
+wait_column down nb:bfd status logical_port=r0-public
+wait_column down bfd status logical_port=r0-public
+check_column "" bfd chassis_name logical_port=r0-public
+
+# Simulate hv1 claiming the chassisredirect port and the BFD session
+# coming up, like ovn-controller would do.
+hv1_uuid=$(fetch_column chassis _uuid name=hv1)
+check ovn-sbctl set port_binding cr-r0-public chassis=$hv1_uuid
+wait_column hv1 bfd chassis_name logical_port=r0-public
+
+sb_bfd_uuid=$(fetch_column bfd _uuid logical_port=r0-public)
+check ovn-sbctl set bfd $sb_bfd_uuid status=up
+wait_column up nb:bfd status logical_port=r0-public
+
+# The BFD monitored route is programmed while the session is up.
+OVS_WAIT_UNTIL([ovn-sbctl dump-flows r0 > r0flows dnl
+&& grep -q "ip4.dst == 100.0.0.0/8" r0flows])
+
+# Release the chassisredirect binding while leaving the Chassis row intact.
+# This specifically exercises the incremental Port_Binding.chassis input.
+# The session must be marked "down" in both databases and the BFD monitored
+# route must be withdrawn.
+check ovn-sbctl clear port_binding cr-r0-public chassis
+wait_column down nb:bfd status logical_port=r0-public
+wait_column down bfd status logical_port=r0-public
+check_column "" bfd chassis_name logical_port=r0-public
+OVS_WAIT_UNTIL([ovn-sbctl dump-flows r0 > r0flows dnl
+&& ! grep -q "ip4.dst == 100.0.0.0/8" r0flows])
+
+# Give the session an owner again: northd must track the owning chassis
+# but must not flip the status to "up" on its own; that is up to
+# ovn-controller's BFD negotiation.
+check ovn-sbctl set port_binding cr-r0-public chassis=$hv1_uuid
+wait_column hv1 bfd chassis_name logical_port=r0-public
+check ovn-nbctl --wait=sb sync
+check_column down nb:bfd status logical_port=r0-public
+check_column down bfd status logical_port=r0-public
+
+# Once "ovn-controller" reports the session up again, the status must
+# propagate to the Northbound as usual.
+check ovn-sbctl set bfd $sb_bfd_uuid status=up
+wait_column up nb:bfd status logical_port=r0-public
+
+# An "admin_down" session must be left untouched when it loses its
+# owner.
+route_uuid=$(fetch_column nb:logical_router_static_route _uuid \
+             ip_prefix="100.0.0.0/8")
+check ovn-nbctl clear logical_router_static_route $route_uuid bfd
+wait_column admin_down nb:bfd status logical_port=r0-public
+wait_column admin_down bfd status logical_port=r0-public
+check ovn-sbctl clear port_binding cr-r0-public chassis
+check ovn-nbctl --wait=sb sync
+check_column admin_down nb:bfd status logical_port=r0-public
+check_column admin_down bfd status logical_port=r0-public
+check_column "" bfd chassis_name logical_port=r0-public
+
+OVN_CLEANUP_NORTHD
+AT_CLEANUP
+])
+
+OVN_FOR_EACH_NORTHD_NO_HV([
+AT_SETUP([BFD ownership on an l3gateway port])
+AT_KEYWORDS([northd-bfd])
+ovn_start
+
+check ovn-sbctl chassis-add hv1 geneve 127.0.0.1
+hv1_uuid=$(fetch_column chassis _uuid name=hv1)
+
+check ovn-nbctl lr-add r0
+check ovn-nbctl set logical_router r0 options:chassis=hv1
+check ovn-nbctl lrp-add r0 r0-public 00:00:20:20:12:13 172.16.0.1/24
+check ovn-nbctl ls-add public
+check ovn-nbctl lsp-add-router-port public public-r0 r0-public
+
+bfd_uuid=$(ovn-nbctl create bfd logical_port=r0-public dst_ip=172.16.0.50)
+check test -n "$bfd_uuid"
+check ovn-nbctl --bfd=$bfd_uuid lr-route-add r0 100.0.0.0/8 172.16.0.50
+
+wait_column l3gateway port_binding type logical_port=r0-public
+check ovn-sbctl set port_binding r0-public chassis=$hv1_uuid
+wait_column hv1 bfd chassis_name logical_port=r0-public
+
+sb_bfd_uuid=$(fetch_column bfd _uuid logical_port=r0-public)
+check ovn-sbctl set bfd $sb_bfd_uuid status=up
+wait_column up nb:bfd status logical_port=r0-public
+
+# The direct l3gateway binding is the owner.  Releasing it must invalidate
+# the stale status through the same incremental Port_Binding input.
+check ovn-sbctl clear port_binding r0-public chassis
+wait_column down nb:bfd status logical_port=r0-public
+wait_column down bfd status logical_port=r0-public
+check_column "" bfd chassis_name logical_port=r0-public
 
 OVN_CLEANUP_NORTHD
 AT_CLEANUP

--- a/tests/ovn-northd.at
+++ b/tests/ovn-northd.at
@@ -4592,6 +4592,118 @@ AT_CLEANUP
 ])
 
 OVN_FOR_EACH_NORTHD_NO_HV([
+AT_SETUP([BFD owner must remain eligible in its HA chassis group])
+AT_KEYWORDS([northd-bfd concept-c])
+ovn_start
+
+check ovn-sbctl chassis-add hv1 geneve 127.0.0.1
+
+check ovn-nbctl lr-add r0
+check ovn-nbctl lrp-add r0 r0-public 00:00:20:20:12:13 172.16.0.1/24
+check ovn-nbctl ls-add public
+check ovn-nbctl lsp-add-router-port public public-r0 r0-public
+check ovn-nbctl ha-chassis-group-add hagrp
+check ovn-nbctl ha-chassis-group-add-chassis hagrp hv1 10
+hagrp_uuid=$(fetch_column nb:ha_chassis_group _uuid name=hagrp)
+check ovn-nbctl --wait=sb set logical_router_port r0-public \
+    ha_chassis_group=$hagrp_uuid
+
+bfd_uuid=$(ovn-nbctl create bfd logical_port=r0-public dst_ip=172.16.0.50)
+check test -n "$bfd_uuid"
+check ovn-nbctl --bfd=$bfd_uuid lr-route-add r0 100.0.0.0/8 172.16.0.50
+
+hv1_uuid=$(fetch_column chassis _uuid name=hv1)
+check ovn-sbctl set port_binding cr-r0-public chassis=$hv1_uuid
+wait_column hv1 bfd chassis_name logical_port=r0-public
+
+sb_bfd_uuid=$(fetch_column bfd _uuid logical_port=r0-public)
+check ovn-sbctl set bfd $sb_bfd_uuid status=up
+wait_column up nb:bfd status logical_port=r0-public
+OVS_WAIT_UNTIL([ovn-sbctl dump-flows r0 > r0flows dnl
+&& grep -q "ip4.dst == 100.0.0.0/8" r0flows])
+
+# Removing hv1 from the group expresses that it is no longer eligible, but
+# deliberately leave its Chassis row and stale Port_Binding ownership in SB.
+# Northd must distrust the stale binding, mark BFD down, and withdraw the
+# route without requiring a chassis deletion or a binding update.
+check ovn-nbctl --wait=sb ha-chassis-group-remove-chassis hagrp hv1
+wait_column down nb:bfd status logical_port=r0-public
+wait_column down bfd status logical_port=r0-public
+check_column "" bfd chassis_name logical_port=r0-public
+check_row_count chassis 1 name=hv1
+check_column $hv1_uuid port_binding chassis logical_port=cr-r0-public
+OVS_WAIT_UNTIL([ovn-sbctl dump-flows r0 > r0flows dnl
+&& ! grep -q "ip4.dst == 100.0.0.0/8" r0flows])
+
+# Re-adding hv1 makes the still-bound chassis eligible again.  Northd restores
+# chassis_name but never invents an operational up state; the controller must
+# report that after BFD negotiation.
+check ovn-nbctl --wait=sb ha-chassis-group-add-chassis hagrp hv1 10
+wait_column hv1 bfd chassis_name logical_port=r0-public
+check_column down nb:bfd status logical_port=r0-public
+check_column down bfd status logical_port=r0-public
+check ovn-sbctl set bfd $sb_bfd_uuid status=up
+wait_column up nb:bfd status logical_port=r0-public
+OVS_WAIT_UNTIL([ovn-sbctl dump-flows r0 > r0flows dnl
+&& grep -q "ip4.dst == 100.0.0.0/8" r0flows])
+
+OVN_CLEANUP_NORTHD
+AT_CLEANUP
+])
+
+OVN_FOR_EACH_NORTHD_NO_HV([
+AT_SETUP([BFD owner must remain eligible in legacy Gateway_Chassis])
+AT_KEYWORDS([northd-bfd concept-c gateway-chassis])
+ovn_start
+
+check ovn-sbctl chassis-add hv1 geneve 127.0.0.1
+check ovn-sbctl chassis-add hv2 geneve 127.0.0.2
+
+check ovn-nbctl lr-add r0
+check ovn-nbctl lrp-add r0 r0-public 00:00:20:20:12:13 172.16.0.1/24
+check ovn-nbctl ls-add public
+check ovn-nbctl lsp-add-router-port public public-r0 r0-public
+check ovn-nbctl lrp-set-gateway-chassis r0-public hv1 20
+check ovn-nbctl --wait=sb lrp-set-gateway-chassis r0-public hv2 10
+
+bfd_uuid=$(ovn-nbctl create bfd logical_port=r0-public dst_ip=172.16.0.50)
+check test -n "$bfd_uuid"
+check ovn-nbctl --bfd=$bfd_uuid lr-route-add r0 100.0.0.0/8 172.16.0.50
+
+hv1_uuid=$(fetch_column chassis _uuid name=hv1)
+check ovn-sbctl set port_binding cr-r0-public chassis=$hv1_uuid
+wait_column hv1 bfd chassis_name logical_port=r0-public
+
+sb_bfd_uuid=$(fetch_column bfd _uuid logical_port=r0-public)
+check ovn-sbctl set bfd $sb_bfd_uuid status=up
+wait_column up nb:bfd status logical_port=r0-public
+OVS_WAIT_UNTIL([ovn-sbctl dump-flows r0 > r0flows dnl
+&& grep -q "ip4.dst == 100.0.0.0/8" r0flows])
+
+# Northd materializes legacy Gateway_Chassis rows as an SB HA chassis group.
+# Remove the bound owner from the legacy list while hv2 keeps the cr-port and
+# its synthesized group alive.  Deliberately retain the stale hv1 binding:
+# hv1 is no longer eligible and therefore must not remain the BFD owner.
+check ovn-nbctl --wait=sb lrp-del-gateway-chassis r0-public hv1
+wait_column down nb:bfd status logical_port=r0-public
+wait_column down bfd status logical_port=r0-public
+check_column "" bfd chassis_name logical_port=r0-public
+check_column $hv1_uuid port_binding chassis logical_port=cr-r0-public
+OVS_WAIT_UNTIL([ovn-sbctl dump-flows r0 > r0flows dnl
+&& ! grep -q "ip4.dst == 100.0.0.0/8" r0flows])
+
+# Re-adding the still-bound chassis restores eligibility and attribution, but
+# northd must leave the operational status down until a controller reports it.
+check ovn-nbctl --wait=sb lrp-set-gateway-chassis r0-public hv1 20
+wait_column hv1 bfd chassis_name logical_port=r0-public
+check_column down nb:bfd status logical_port=r0-public
+check_column down bfd status logical_port=r0-public
+
+OVN_CLEANUP_NORTHD
+AT_CLEANUP
+])
+
+OVN_FOR_EACH_NORTHD_NO_HV([
 AT_SETUP([ovn -- check CoPP config])
 AT_KEYWORDS([northd-CoPP])
 

--- a/tests/ovn.at
+++ b/tests/ovn.at
@@ -8437,6 +8437,89 @@ AT_CLEANUP
 ])
 
 OVN_FOR_EACH_NORTHD([
+AT_SETUP([BFD - live HA eligibility transition with RBAC])
+AT_KEYWORDS([bfd concept-c rbac])
+ovn_start
+
+net_add n1
+for hv in hv1 hv2; do
+    sim_add $hv
+    as $hv
+    check ovs-vsctl add-br br-phys
+done
+as hv1 ovn_attach n1 br-phys 192.168.0.1
+as hv2 ovn_attach n1 br-phys 192.168.0.2
+
+check ovn-nbctl lr-add R1
+check ovn-nbctl ls-add sw0
+check ovn-nbctl ls-add public
+check ovn-nbctl lrp-add R1 rp-sw0 00:00:01:01:02:03 192.168.1.1/24
+check ovn-nbctl lrp-add R1 rp-public 00:00:02:01:02:03 172.16.1.1/24
+check ovn-nbctl lsp-add sw0 sw0-rp -- set Logical_Switch_Port sw0-rp \
+    type=router options:router-port=rp-sw0 -- lsp-set-addresses sw0-rp router
+check ovn-nbctl lsp-add public public-rp -- set Logical_Switch_Port \
+    public-rp type=router options:router-port=rp-public \
+    -- lsp-set-addresses public-rp router
+
+check ovn-nbctl ha-chassis-group-add hagrp
+check ovn-nbctl ha-chassis-group-add-chassis hagrp hv1 20
+check ovn-nbctl ha-chassis-group-add-chassis hagrp hv2 10
+hagrp_uuid=$(fetch_column nb:ha_chassis_group _uuid name=hagrp)
+check ovn-nbctl --wait=hv set logical_router_port rp-public \
+    ha_chassis_group=$hagrp_uuid
+
+# Both controllers are live.  The higher-priority member claims the redirect
+# binding and owns the BFD session.
+OVS_WAIT_UNTIL([
+    hv1_uuid=$(ovn-sbctl --bare --columns _uuid list chassis hv1)
+    cr_ch=$(ovn-sbctl --bare --columns chassis list port_binding cr-rp-public)
+    test -n "$hv1_uuid" && test "$cr_ch" = "$hv1_uuid"
+])
+
+# The peer never answers, so each live owner has local state "down".  This
+# makes it possible to prove controller reconciliation through the
+# ovn-controller RBAC connection without synthesizing a BFD peer.
+check ovn-nbctl --bfd lr-route-add R1 100.0.0.0/8 172.16.1.50 rp-public
+wait_column hv1 bfd chassis_name logical_port=rp-public
+wait_column down bfd status logical_port=rp-public
+check ovn-sbctl set bfd . status=up
+wait_column down bfd status logical_port=rp-public
+
+# Excluding the current owner makes hv1 release the binding and hv2 claim it.
+# The BFD row must follow the new eligible owner, and hv2 must be able to
+# reconcile status through RBAC without persistent writer churn.
+check ovn-nbctl --wait=hv ha-chassis-group-remove-chassis hagrp hv1
+OVS_WAIT_UNTIL([
+    hv2_uuid=$(ovn-sbctl --bare --columns _uuid list chassis hv2)
+    cr_ch=$(ovn-sbctl --bare --columns chassis list port_binding cr-rp-public)
+    test -n "$hv2_uuid" && test "$cr_ch" = "$hv2_uuid"
+])
+wait_column hv2 bfd chassis_name logical_port=rp-public
+check ovn-sbctl set bfd . status=up
+wait_column down bfd status logical_port=rp-public
+
+# Re-add hv1, then exclude hv2 to exercise recovery and a second live owner
+# transition.  Northd restores attribution; the controller remains the only
+# component that repairs the operational status for an eligible owner.
+check ovn-nbctl ha-chassis-group-add-chassis hagrp hv1 20
+check ovn-nbctl --wait=hv ha-chassis-group-remove-chassis hagrp hv2
+OVS_WAIT_UNTIL([
+    hv1_uuid=$(ovn-sbctl --bare --columns _uuid list chassis hv1)
+    cr_ch=$(ovn-sbctl --bare --columns chassis list port_binding cr-rp-public)
+    test -n "$hv1_uuid" && test "$cr_ch" = "$hv1_uuid"
+])
+wait_column hv1 bfd chassis_name logical_port=rp-public
+check ovn-sbctl set bfd . status=up
+wait_column down bfd status logical_port=rp-public
+
+AT_CHECK([grep -E "not authorized|RBAC.*denied" hv1/ovn-controller.log \
+          hv2/ovn-controller.log], [1], [], [ignore])
+
+OVN_CLEANUP([hv1],[hv2])
+AT_CLEANUP
+])
+
+OVN_FOR_EACH_NORTHD([
 AT_SETUP([spine-leaf: 3 HVs, 3 LSs, connected via distributed spine switch])
 AT_KEYWORDS([spine leaf])
 CHECK_SCAPY

--- a/tests/ovn.at
+++ b/tests/ovn.at
@@ -47044,3 +47044,81 @@ AT_CHECK([grep "skipping output to input port" \
 OVN_CLEANUP([hv1])
 AT_CLEANUP
 ])
+
+OVN_FOR_EACH_NORTHD([
+AT_SETUP([BFD - reconcile SB status with local session state])
+AT_KEYWORDS([bfd])
+ovn_start
+
+net_add n1
+sim_add hv1
+as hv1
+ovs-vsctl add-br br-phys
+ovn_attach n1 br-phys 192.168.0.1
+
+check ovn-nbctl lr-add R1
+check ovn-nbctl ls-add sw0
+check ovn-nbctl ls-add public
+
+check ovn-nbctl lrp-add R1 rp-sw0 00:00:01:01:02:03 192.168.1.1/24
+check ovn-nbctl lrp-add R1 rp-public 00:00:02:01:02:03 172.16.1.1/24
+check ovn-nbctl lrp-set-gateway-chassis rp-public hv1
+
+check ovn-nbctl lsp-add sw0 sw0-rp -- set Logical_Switch_Port sw0-rp \
+    type=router options:router-port=rp-sw0 -- lsp-set-addresses sw0-rp router
+
+check ovn-nbctl lsp-add public public-rp -- set Logical_Switch_Port \
+    public-rp type=router options:router-port=rp-public \
+    -- lsp-set-addresses public-rp router
+
+# Wait for the distributed gateway port to be claimed by hv1.
+OVS_WAIT_UNTIL([
+    hv1_uuid=$(ovn-sbctl --bare --columns _uuid list chassis hv1)
+    cr_ch=$(ovn-sbctl --bare --columns chassis list port_binding cr-rp-public)
+    test -n "$hv1_uuid" && test "$cr_ch" = "$hv1_uuid"
+])
+
+# Create a BFD session towards a peer that never answers: the local
+# session on hv1 stays down.
+check ovn-nbctl --bfd lr-route-add R1 100.0.0.0/8 172.16.1.50 rp-public
+check ovn-nbctl --wait=sb sync
+wait_row_count bfd 1
+
+# ovn-northd only fills in chassis_name when the logical port is bound,
+# which never happens for a distributed gateway port, and the SB RBAC
+# permissions for the BFD table (used when the sandbox connects the
+# chassis over SSL) authorize status updates through chassis_name.
+# Attribute the session to hv1 the way an l3gateway row would be.
+check ovn-sbctl set bfd . chassis_name=hv1
+
+wait_column "down" bfd status logical_port=rp-public
+
+# Scenario 1: externally rewrite the status of the SB row while the
+# local session state does not change.  Since no state machine
+# transition happens, only the reconciliation logic in ovn-controller
+# can repair the row.
+check ovn-sbctl set bfd . status=up
+wait_column "down" bfd status logical_port=rp-public
+
+check ovn-sbctl set bfd . status=init
+wait_column "down" bfd status logical_port=rp-public
+
+# Scenario 2: a session (re)created while the SB row holds a stale
+# status.  Stop ovn-controller, fake a stale "up" left over from a
+# previous incarnation, then restart the controller: the fresh session
+# never establishes (no peer), so without reconciliation the bogus "up"
+# would persist forever.
+check as hv1 ovn-appctl -t ovn-controller exit
+check ovn-sbctl set bfd . status=up
+
+as hv1 start_daemon ovn-controller
+OVS_WAIT_UNTIL([
+    hv1_uuid=$(ovn-sbctl --bare --columns _uuid list chassis hv1)
+    cr_ch=$(ovn-sbctl --bare --columns chassis list port_binding cr-rp-public)
+    test -n "$hv1_uuid" && test "$cr_ch" = "$hv1_uuid"
+])
+wait_column "down" bfd status logical_port=rp-public
+
+OVN_CLEANUP([hv1])
+AT_CLEANUP
+])


### PR DESCRIPTION
Completes the OVN half of the Concept C hard-crash handling discussed in #320.

This pull request is intentionally stacked on #321 and #323. While those dependencies are open, the branch contains their rebased changes followed by the Concept C commit `5c8fdbe365`. It remains a draft until the dependencies merge, after which it should be rebased to contain only its own commit.

A `chassisredirect` Port_Binding can remain bound after the bound chassis is removed from its associated SB HA chassis group. In that state, residency alone is not valid evidence that the chassis remains eligible to own the BFD session. This change therefore requires the bound chassis to remain a member of the Port_Binding's SB HA chassis group. If it is not, #321's no-valid-owner path marks non-`admin_down` NB/SB BFD status down, clears `chassis_name`, and existing route processing withdraws the nexthop.

The mechanism adds no heartbeat schema, wall-clock comparison, or CMS writer of operational `BFD.status`. Chassis liveness remains an opt-in CMS policy decision: the companion Neutron change removes a confirmed-silent chassis only from scoped BFD-only HA groups, and northd translates the resulting eligibility change into BFD truth.

`SB_ha_chassis_group` is an explicit input of `bfd_sync`, so membership-only changes cannot leave stale BFD state. The schema documentation describes the eligibility rule.

Validation on current OVN main and the complete dependency stack includes:

- clean build;
- #321 no-owner and direct `l3gateway` coverage;
- both #323 controller-reconciliation modes;
- native `HA_Chassis_Group` and legacy `Gateway_Chassis` eligibility tests;
- a real-controller/RBAC exclusion, release, recovery, and status-repair test.

All eight focused stack tests pass. The exact behavior was also deployed on OVN 24.03 in a two-node FRR lab and exercised through short and long SB partitions, a stale retained binding, `admin_down`, controller reconciliation, maintenance-worker restart, persisted exclusion, startup grace, fresh-generation recovery, and 8/8 ECMP traffic.

Companion Neutron policy:

- RFE: https://bugs.launchpad.net/bugs/2165165
- Gerrit review: https://review.opendev.org/c/openstack/neutron/+/1002536

Depends-on: #321

Depends-on: #323

Related-to: #320

Assisted-by: GPT-5