### PR TITLE
pinctrl: Return NODATA for missing address family

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -2,6 +2,11 @@ Post v26.09.0
 --------------
    - Removed implementations of the commit_ecmp_nh, chk_ecmp_nh, and
      chk_ecmp_nh_mac actions from the code.
+   - ovn-controller now answers a DNS query for an "ovn-owned" name that has
+     no record of the requested type (e.g. AAAA for an IPv4-only name) with
+     NODATA (RCODE 0, empty answer) instead of REFUSED (RCODE 5).  Resolvers
+     that send A and AAAA in parallel, such as musl, treated REFUSED as no
+     reply and failed the whole lookup after a timeout.
    - Mark tunnel ports as transient (other_config:transient=true) when the
      local chassis is a member of an HA chassis group.
      Systems which invoke ovs-ctl --delete-transient-ports during OVS startup

--- a/controller/pinctrl.c
+++ b/controller/pinctrl.c
@@ -3444,7 +3444,6 @@ dns_build_ptr_answer(
     free(encoded);
 }
 
-#define DNS_RCODE_SERVER_REFUSE 0x5
 #define DNS_QUERY_TYPE_CLASS_LEN (2 * sizeof(ovs_be16))
 
 /* Called with in the pinctrl_handler thread context. */
@@ -3459,7 +3458,7 @@ pinctrl_handle_dns_lookup(
     enum ofputil_protocol proto = ofputil_protocol_from_ofp_version(version);
     struct dp_packet *pkt_out_ptr = NULL;
     uint32_t success = 0;
-    bool send_refuse = false;
+    bool send_nodata = false;
 
     /* Track total DNS queries received */
     COVERAGE_INC(dns_query_total);
@@ -3635,22 +3634,30 @@ pinctrl_handle_dns_lookup(
         free(ipv4_order);
         free(ipv6_order);
 
-        /* DNS is configured with a record for this domain with
-         * an IPv4/IPV6 only, so instead of ignoring this A/AAAA query,
-         * we can reply with  RCODE = 5 (server refuses) and that
-         * will speed up the DNS process by not letting the customer
-         * wait for a timeout.
+        /* DNS is configured with a record for this name with addresses of
+         * one family only, so a query for the other family has to be
+         * answered rather than ignored, or the client waits for a timeout.
+         *
+         * The answer is NODATA (RFC 2308, section 2.2): RCODE 0 with an
+         * empty answer section, which is what an authoritative server says
+         * for a name that exists but has no record of the requested type.
+         * It used to be RCODE 5 (REFUSED), which resolvers do not treat as
+         * an answer: musl ignores REFUSED and keeps waiting on that query,
+         * so a getaddrinfo() that sent A and AAAA in parallel failed after
+         * the full timeout even though the A query was answered at once.
+         * NODATA is accepted by every resolver as "no addresses of this
+         * type", and the other query's answer is used.
          */
         if (ovn_owned && (query_type == DNS_QUERY_TYPE_AAAA ||
             query_type == DNS_QUERY_TYPE_A) && !ancount) {
-            send_refuse = true;
+            send_nodata = true;
             COVERAGE_INC(dns_unsupported_ovn_owned);
         }
 
         destroy_lport_addresses(&ip_addrs);
     }
 
-    if (!ancount && !send_refuse) {
+    if (!ancount && !send_nodata) {
         ofpbuf_uninit(&dns_answer);
         goto exit;
     }
@@ -3685,10 +3692,6 @@ pinctrl_handle_dns_lookup(
 
     /* Set the answer RRs. */
     out_dns_header->ancount = htons(ancount);
-    if (send_refuse) {
-        /* set RCODE = 5 (server refuses). */
-        out_dns_header->hi_flag |= DNS_RCODE_SERVER_REFUSE;
-    }
     out_dns_header->arcount = 0;
 
     /* Copy the Query section. */

--- a/ovn-nb.xml
+++ b/ovn-nb.xml
@@ -6458,9 +6458,10 @@ or
         locally and don't care about IPv6 only interested in IPv4 or
         vice versa.
 
-        This will let ovn send IPv4 DNS reply and reject/ignore IPv6
-        queries to save the waiting for a timeout on those uninteresting
-        queries.
+        This will let ovn send IPv4 DNS replies and answer IPv6 queries
+        for such a name with NODATA (RCODE 0 and an empty answer section),
+        so the client neither waits for a timeout nor treats the name as
+        unknown; the same applies to IPv4 queries for an IPv6-only name.
       </p>
     </column>
 

--- a/tests/ovn.at
+++ b/tests/ovn.at
@@ -12517,8 +12517,9 @@ rm -f 1.expected
 rm -f 2.expected
 
 # send AAAA query for a server known domain that don't have
-# any IPV6 address associated with this domain, and expected
-# server refused DNS reply to save the sender time of waiting for timeout.
+# any IPV6 address associated with this domain, and expect a NODATA
+# reply (RCODE 0, no answer) so the sender neither waits for a timeout
+# nor treats the name as unknown.
 AS_BOX([Test IPv6 (AAAA records) NO timeout.])
 # Add back the DNS options for ls1-lp1 without ipv6.
 check ovn-nbctl remove DNS $DNS1 records vm1.ovn.org
@@ -12539,8 +12540,8 @@ test_dns 2 f00000000002 f000000000f0 $src_ip $dst_ip $dns_reply $dns_req_data $d
 OVS_WAIT_UNTIL([test 13 = `cat ofctl_monitor*.log | grep -c NXT_RESUME`])
 
 $PYTHON "$ovs_srcdir/utilities/ovs-pcap.in" hv1/vif2-tx.pcap > 2.packets
-# dns hdr with server refuse RCODE
-echo "01028125"  > expout
+# dns hdr with RCODE 0 and no answer (NODATA)
+echo "01028120"  > expout
 # only check for the DNS HDR flags since we are not getting any DNS answer
 AT_CHECK([cat 2.packets | cut -c -92 | cut -c 85-], [0], [expout])
 
@@ -12550,8 +12551,9 @@ rm -f 1.expected
 rm -f 2.expected
 
 # send A query for a server known domain that don't have
-# any IPv4 address associated with this domain, and expected
-# server refused DNS reply to save the sender time of waiting for timeout.
+# any IPv4 address associated with this domain, and expect a NODATA
+# reply (RCODE 0, no answer) so the sender neither waits for a timeout
+# nor treats the name as unknown.
 AS_BOX([Test IPv4 (A records) NO timeout.])
 # Add back the DNS options for ls1-lp1 without ipv4.
 check ovn-nbctl remove DNS $DNS1 records vm1.ovn.org
@@ -12572,8 +12574,8 @@ test_dns 2 f00000000002 f000000000f0 $src_ip $dst_ip $dns_reply $dns_req_data $d
 OVS_WAIT_UNTIL([test 14 = `cat ofctl_monitor*.log | grep -c NXT_RESUME`])
 
 $PYTHON "$ovs_srcdir/utilities/ovs-pcap.in" hv1/vif2-tx.pcap > 2.packets
-# dns hdr with server refuse RCODE
-echo "01028125"  > expout
+# dns hdr with RCODE 0 and no answer (NODATA)
+echo "01028120"  > expout
 # only check for the DNS HDR flags since we are not getting any DNS answer
 AT_CHECK([cat 2.packets | cut -c -92 | cut -c 85-], [0], [expout])
 


### PR DESCRIPTION
An ovn-owned DNS record with addresses from only one family currently answers a query for the other family with REFUSED. musl ignores that response and waits for the query to time out, which can make getaddrinfo() fail even though the parallel query was answered immediately.

Return NODATA instead: RCODE 0 with an empty answer section, as specified for an existing name without the requested record type. Update the northbound documentation, NEWS, and the existing A/AAAA tests accordingly.

Testing:
- python3 utilities/checkpatch.py -1 fb555ca75 (0 errors; one existing warning for the 86-character commit subject)
- git diff --check upstream/main..fb555ca75
- Full make check not run because this checkout has no configured build tree.